### PR TITLE
Fix ML pipeline workflow step ordering

### DIFF
--- a/.github/workflows/run-ml-pipeline.yml
+++ b/.github/workflows/run-ml-pipeline.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build feature matrix
         run: python ml/pipeline.py
 
+      - name: Generate feature matrix files
+        run: python ml/feature_matrix.py
+
       - name: Upload ML artifacts to Supabase Storage
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
@@ -37,7 +40,6 @@ jobs:
           UPLOAD_GROUP: all
           SKIP_MISSING: "1"
         run: python upload_to_supabase_storage.py
-        run: python ml/feature_matrix.py
 
       - name: Train models
         run: python ml/train_ml_models.py


### PR DESCRIPTION
### Motivation
- The GitHub Actions workflow validation failed because the `Upload ML artifacts to Supabase Storage` step contained duplicate `run` keys, making the workflow invalid.

### Description
- Moved `python ml/feature_matrix.py` into its own `Generate feature matrix files` step and removed the duplicate `run` from the upload step so every step has a single `run` entry.

### Testing
- Verified the change was written and committed (`git add .github/workflows/run-ml-pipeline.yml` and `git commit -m "Fix ML pipeline workflow step"`) and inspected the workflow file (`nl -ba .github/workflows/run-ml-pipeline.yml`) to confirm the new step; no automated unit tests were run since this is a workflow-only fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983e847c04c832bb712328184e686da)