### PR TITLE
Add daily auto-prediction pipeline, Supabase schema, Streamlit dashboards, and ensemble optimizer

### DIFF
--- a/.github/workflows/daily_auto_predict.yml
+++ b/.github/workflows/daily_auto_predict.yml
@@ -1,0 +1,32 @@
+name: Daily Auto Predict
+
+on:
+  schedule:
+    - cron: "0 15 * * *"
+  workflow_dispatch: {}
+
+jobs:
+  auto-predict:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      MODEL_VERSION: ${{ secrets.MODEL_VERSION }}
+      EDGE_MIN: "3.0"
+      EDGE_TIER2: "6.0"
+      EDGE_TIER3: "9.0"
+      DAYS_AHEAD: "1"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run daily auto prediction
+        run: |
+          python scripts/daily_auto_predict.py

--- a/ml/optimize_ensemble.py
+++ b/ml/optimize_ensemble.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Grid-search ensemble optimizer for weighted averages.
+
+Example:
+  python ml/optimize_ensemble.py \
+    --input ml/predictions_latest.csv \
+    --model-cols model_a_pred,model_b_pred \
+    --target-col actual_margin_home \
+    --metric mae \
+    --step 0.05
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from itertools import product
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+import numpy as np
+import pandas as pd
+
+
+def _parse_cols(text: str) -> List[str]:
+    return [c.strip() for c in text.split(",") if c.strip()]
+
+
+def _generate_weights(n: int, step: float) -> List[Tuple[float, ...]]:
+    grid = np.arange(0.0, 1.0 + 1e-9, step)
+    combos = []
+    for weights in product(grid, repeat=n):
+        if abs(sum(weights) - 1.0) <= 1e-6:
+            combos.append(tuple(float(w) for w in weights))
+    return combos
+
+
+def _metric_mae(pred: np.ndarray, target: np.ndarray) -> float:
+    return float(np.nanmean(np.abs(pred - target)))
+
+
+def _metric_mse(pred: np.ndarray, target: np.ndarray) -> float:
+    return float(np.nanmean((pred - target) ** 2))
+
+
+def _metric_hit_rate(pred: np.ndarray, target: np.ndarray) -> float:
+    return float(np.nanmean((pred > 0) == (target > 0)))
+
+
+def _select_metric(name: str):
+    if name == "mae":
+        return _metric_mae, "min"
+    if name == "mse":
+        return _metric_mse, "min"
+    if name == "hit_rate":
+        return _metric_hit_rate, "max"
+    raise ValueError("metric must be one of: mae, mse, hit_rate")
+
+
+def optimize(
+    df: pd.DataFrame,
+    model_cols: List[str],
+    target_col: str,
+    metric: str,
+    step: float,
+) -> Dict[str, object]:
+    for col in model_cols + [target_col]:
+        if col not in df.columns:
+            raise ValueError(f"Missing column: {col}")
+
+    matrix = df[model_cols].to_numpy(dtype=float)
+    target = df[target_col].to_numpy(dtype=float)
+
+    metric_fn, mode = _select_metric(metric)
+    best_score = None
+    best_weights = None
+
+    weights_grid = _generate_weights(len(model_cols), step)
+    if not weights_grid:
+        raise ValueError("No weight combinations generated; try a smaller --step.")
+
+    for weights in weights_grid:
+        pred = np.average(matrix, axis=1, weights=np.array(weights))
+        score = metric_fn(pred, target)
+        if best_score is None:
+            best_score = score
+            best_weights = weights
+            continue
+        if mode == "min" and score < best_score:
+            best_score = score
+            best_weights = weights
+        if mode == "max" and score > best_score:
+            best_score = score
+            best_weights = weights
+
+    return {
+        "metric": metric,
+        "score": best_score,
+        "weights": {col: float(w) for col, w in zip(model_cols, best_weights)},
+        "rows": int(len(df)),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="Path to CSV with model columns + target.")
+    parser.add_argument("--model-cols", required=True, help="Comma-separated list of model prediction columns.")
+    parser.add_argument("--target-col", required=True, help="Target column name.")
+    parser.add_argument("--metric", default="mae", choices=["mae", "mse", "hit_rate"])
+    parser.add_argument("--step", type=float, default=0.05, help="Grid step (e.g., 0.05).")
+    parser.add_argument("--out", default="ml/ensemble_weights.json", help="Output JSON path.")
+    args = parser.parse_args()
+
+    df = pd.read_csv(Path(args.input))
+    model_cols = _parse_cols(args.model_cols)
+
+    result = optimize(df, model_cols, args.target_col, args.metric, args.step)
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/pages/1_Daily_Dashboard.py
+++ b/pages/1_Daily_Dashboard.py
@@ -1,0 +1,104 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import streamlit as st
+from supabase import create_client
+
+import espn_boxscore_builder as espn
+
+
+st.set_page_config(page_title="Daily Dashboard", page_icon="📅", layout="wide")
+
+
+def _get_supabase_client():
+    url = (os.getenv("SUPABASE_URL") or "").strip()
+    key = (os.getenv("SUPABASE_ANON_KEY") or "").strip()
+    if not url or not key:
+        return None
+    return create_client(url, key)
+
+
+def _load_predictions() -> pd.DataFrame:
+    client = _get_supabase_client()
+    if client is None:
+        path = "ml/predictions_latest.csv"
+        if os.path.exists(path):
+            return pd.read_csv(path)
+        return pd.DataFrame()
+
+    start = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=1)
+    try:
+        resp = (
+            client.table("predictions")
+            .select("*")
+            .gte("game_datetime_utc", start.isoformat())
+            .lt("game_datetime_utc", end.isoformat())
+            .execute()
+        )
+        return pd.DataFrame(resp.data or [])
+    except Exception:
+        path = "ml/predictions_latest.csv"
+        if os.path.exists(path):
+            return pd.read_csv(path)
+        return pd.DataFrame()
+
+
+def _load_scoreboard() -> pd.DataFrame:
+    today = datetime.now().strftime("%Y%m%d")
+    rows = espn.fetch_scoreboard_games(today)
+    return pd.DataFrame(rows)
+
+
+st.title("Daily Dashboard")
+st.caption("Today's games with model edges and bet recommendations.")
+
+preds = _load_predictions()
+scoreboard = _load_scoreboard()
+
+if scoreboard.empty:
+    st.warning("No ESPN scoreboard data returned.")
+    st.stop()
+
+if preds.empty:
+    st.info("No predictions found. Run the pipeline to populate predictions.")
+
+if "pred_margin_home" not in preds.columns and "pred_spread" in preds.columns:
+    preds["pred_margin_home"] = preds["pred_spread"]
+
+scoreboard["game_id"] = scoreboard["game_id"].astype(str)
+if "event_id" in preds.columns:
+    preds["event_id"] = preds["event_id"].astype(str)
+    merged = preds.merge(scoreboard, left_on="event_id", right_on="game_id", how="left", suffixes=("", "_game"))
+elif "external_game_id" in preds.columns:
+    preds["external_game_id"] = preds["external_game_id"].astype(str)
+    merged = preds.merge(scoreboard, left_on="external_game_id", right_on="game_id", how="left", suffixes=("", "_game"))
+else:
+    merged = scoreboard.copy()
+
+if "edge_spread" not in merged.columns:
+    if "pred_margin_home" in merged.columns:
+        merged["edge_spread"] = merged["pred_margin_home"] - merged.get("market_spread")
+    else:
+        merged["edge_spread"] = pd.NA
+
+edge_min = st.slider("Minimum edge", 0.0, 15.0, 3.0, 0.5)
+
+display_cols = [
+    "game_datetime_utc",
+    "home_team",
+    "away_team",
+    "market_spread",
+    "pred_margin_home",
+    "edge_spread",
+    "bet_side",
+    "bet_units",
+]
+
+table = merged.copy()
+table = table[table["edge_spread"].abs() >= edge_min] if "edge_spread" in table else table
+table = table.sort_values("edge_spread", ascending=False, key=lambda s: s.abs())
+table = table[[c for c in display_cols if c in table.columns]]
+
+st.dataframe(table, use_container_width=True)

--- a/pages/2_Model_Reports.py
+++ b/pages/2_Model_Reports.py
@@ -1,0 +1,125 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+import pandas as pd
+import streamlit as st
+from supabase import create_client
+
+
+st.set_page_config(page_title="Model Reports", page_icon="📊", layout="wide")
+
+
+def _get_supabase_client():
+    url = (os.getenv("SUPABASE_URL") or "").strip()
+    key = (os.getenv("SUPABASE_ANON_KEY") or "").strip()
+    if not url or not key:
+        return None
+    return create_client(url, key)
+
+
+def _load_predictions() -> pd.DataFrame:
+    client = _get_supabase_client()
+    if client is None:
+        path = "ml/predictions_latest.csv"
+        if os.path.exists(path):
+            return pd.read_csv(path)
+        return pd.DataFrame()
+
+    start = datetime.now(timezone.utc) - timedelta(days=30)
+    try:
+        resp = (
+            client.table("predictions")
+            .select("*")
+            .gte("game_datetime_utc", start.isoformat())
+            .execute()
+        )
+        return pd.DataFrame(resp.data or [])
+    except Exception:
+        path = "ml/predictions_latest.csv"
+        if os.path.exists(path):
+            return pd.read_csv(path)
+        return pd.DataFrame()
+
+
+st.title("Model Reports")
+st.caption("Leaderboards for win%, ROI, and hit rate. Rolling charts are optional.")
+
+preds = _load_predictions()
+if preds.empty:
+    st.warning("No predictions available.")
+    st.stop()
+
+preds["model_version"] = preds.get("model_version", "unknown")
+preds["pred_spread"] = preds.get("pred_spread", preds.get("pred_margin_home"))
+preds["actual_margin_home"] = preds.get("actual_margin_home")
+preds["market_spread"] = preds.get("market_spread")
+
+has_actuals = preds["actual_margin_home"].notna()
+preds["winner_hit"] = np.where(
+    has_actuals,
+    (preds["pred_spread"] > 0) == (preds["actual_margin_home"] > 0),
+    np.nan,
+)
+
+preds["bet_signal"] = preds.get("bet_signal", False)
+preds["bet_side"] = preds.get("bet_side")
+
+def _bet_result(row):
+    if not row.get("bet_signal"):
+        return np.nan
+    actual = row.get("actual_margin_home")
+    spread = row.get("market_spread")
+    if pd.isna(actual) or pd.isna(spread):
+        return np.nan
+    if row.get("bet_side") == "home":
+        return 1.0 if actual > spread else 0.0 if actual < spread else 0.5
+    if row.get("bet_side") == "away":
+        return 1.0 if actual < spread else 0.0 if actual > spread else 0.5
+    return np.nan
+
+
+preds["bet_result"] = preds.apply(_bet_result, axis=1)
+
+def _roi(series: pd.Series) -> float:
+    if series.dropna().empty:
+        return float("nan")
+    wins = (series == 1.0).sum()
+    losses = (series == 0.0).sum()
+    pushes = (series == 0.5).sum()
+    stake = wins + losses + pushes
+    if stake == 0:
+        return float("nan")
+    pnl = wins * 0.91 - losses * 1.0
+    return pnl / stake
+
+
+summary = (
+    preds.groupby("model_version", dropna=False)
+    .agg(
+        games=("pred_spread", "count"),
+        hit_rate=("winner_hit", "mean"),
+        bets=("bet_signal", "sum"),
+        roi=("bet_result", _roi),
+    )
+    .reset_index()
+)
+
+st.subheader("Leaderboard")
+st.dataframe(summary, use_container_width=True)
+
+with st.expander("Rolling hit rate (optional)", expanded=False):
+    show = st.checkbox("Show rolling chart", value=False)
+    if show:
+        if "game_datetime_utc" in preds.columns:
+            preds["game_datetime_utc"] = pd.to_datetime(preds["game_datetime_utc"], utc=True, errors="coerce")
+            series = (
+                preds.sort_values("game_datetime_utc")
+                .set_index("game_datetime_utc")["winner_hit"]
+                .rolling(20, min_periods=5)
+                .mean()
+                .dropna()
+            )
+            st.line_chart(series)
+        else:
+            st.info("No game_datetime_utc column available for rolling chart.")

--- a/scripts/daily_auto_predict.py
+++ b/scripts/daily_auto_predict.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+Daily auto-prediction pipeline:
+1) Pull ESPN scoreboard games.
+2) Build model feature matrix.
+3) Run ML predictions.
+4) Calculate edges vs Vegas.
+5) Upsert to Supabase (teams, games, market_lines, predictions, dq_audit, raw_games).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional, Tuple
+
+import pandas as pd
+from supabase import create_client
+
+import espn_boxscore_builder as espn
+from ml.feature_matrix import build_feature_matrix, BuildConfig
+from ml.predict_ml import predict, PredictConfig
+
+
+SOURCE = "ESPN"
+EDGE_MIN = float(os.getenv("EDGE_MIN", "3.0"))
+EDGE_TIER2 = float(os.getenv("EDGE_TIER2", "6.0"))
+EDGE_TIER3 = float(os.getenv("EDGE_TIER3", "9.0"))
+MODEL_VERSION = os.getenv("MODEL_VERSION", "").strip()
+DAYS_AHEAD = int(os.getenv("DAYS_AHEAD", "1"))
+SEASON = int(os.getenv("SEASON", datetime.now().year + (1 if datetime.now().month >= 7 else 0)))
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _uuid_for_team(season: int, source: str, name: str) -> str:
+    key = f"{season}:{source}:{name.lower().strip()}"
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, key))
+
+
+def _uuid_for_game(season: int, source: str, external_game_id: str) -> str:
+    key = f"{season}:{source}:{external_game_id}"
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, key))
+
+
+def _safe_num(value: object) -> Optional[float]:
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _has_value(value: object) -> bool:
+    return _safe_num(value) is not None
+
+
+def _has_text(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, float) and math.isnan(value):
+        return False
+    return bool(str(value).strip())
+
+
+def _sanitize_payload(payload: Dict[str, object]) -> Dict[str, object]:
+    cleaned = {}
+    for key, value in payload.items():
+        if isinstance(value, float) and math.isnan(value):
+            cleaned[key] = None
+        else:
+            cleaned[key] = value
+    return cleaned
+
+
+def _parse_game_datetime(row: Dict[str, object]) -> Optional[str]:
+    if _has_text(row.get("game_datetime_utc")):
+        return str(row.get("game_datetime_utc"))
+    if _has_text(row.get("date")):
+        try:
+            dt = datetime.strptime(str(row.get("date")), "%Y%m%d").replace(tzinfo=timezone.utc)
+            return dt.isoformat()
+        except ValueError:
+            return None
+    return None
+
+
+def _confidence_from_edge(edge: Optional[float]) -> Optional[float]:
+    if edge is None:
+        return None
+    return float(1.0 - math.exp(-abs(edge) / 6.0))
+
+
+def _bet_units(edge: Optional[float]) -> Optional[float]:
+    if edge is None:
+        return None
+    abs_edge = abs(edge)
+    if abs_edge >= EDGE_TIER3:
+        return 3.0
+    if abs_edge >= EDGE_TIER2:
+        return 2.0
+    if abs_edge >= EDGE_MIN:
+        return 1.0
+    return 0.0
+
+
+def _bet_side(edge: Optional[float]) -> Optional[str]:
+    if edge is None or abs(edge) < EDGE_MIN:
+        return None
+    return "home" if edge > 0 else "away"
+
+
+def _validate_game(row: Dict[str, object]) -> Tuple[str, List[str]]:
+    reasons: List[str] = []
+    if not _has_text(row.get("game_datetime_utc")) and not _has_text(row.get("date")):
+        reasons.append("missing_game_datetime")
+    if not row.get("home_team") or not row.get("away_team"):
+        reasons.append("missing_team_name")
+    if row.get("completed") and (not _has_value(row.get("home_score")) or not _has_value(row.get("away_score"))):
+        reasons.append("missing_final_score")
+    if not _has_value(row.get("market_spread")) and not _has_value(row.get("market_total")):
+        reasons.append("missing_market_lines")
+
+    if "missing_game_datetime" in reasons or "missing_team_name" in reasons:
+        return "rejected", reasons
+    if reasons:
+        return "partial", reasons
+    return "verified", reasons
+
+
+def _load_supabase():
+    url = (os.getenv("SUPABASE_URL") or "").strip()
+    key = (os.getenv("SUPABASE_SERVICE_ROLE_KEY") or "").strip()
+    if not url or not key:
+        raise RuntimeError("SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing.")
+    return create_client(url, key)
+
+
+@dataclass(frozen=True)
+class Counts:
+    pulled: int = 0
+    games_upserted: int = 0
+    markets_upserted: int = 0
+    predictions_upserted: int = 0
+    rejected: int = 0
+
+
+def fetch_scoreboard() -> pd.DataFrame:
+    today = datetime.now().strftime("%Y%m%d")
+    dates = [today]
+    for i in range(1, DAYS_AHEAD + 1):
+        dates.append((datetime.now() + timedelta(days=i)).strftime("%Y%m%d"))
+
+    rows: List[Dict[str, object]] = []
+    for d in dates:
+        rows.extend(espn.fetch_scoreboard_games(d))
+    return pd.DataFrame(rows)
+
+
+def build_ml_outputs() -> pd.DataFrame:
+    build_feature_matrix(BuildConfig())
+    predict(PredictConfig())
+    return pd.read_csv("ml/predictions_latest.csv")
+
+
+def upsert_rows(client, schema: str, table: str, rows: List[Dict[str, object]], on_conflict: Optional[str] = None):
+    if not rows:
+        return 0
+    payload = rows if len(rows) > 1 else rows[0]
+    req = client.schema(schema).table(table)
+    if on_conflict:
+        resp = req.upsert(payload, on_conflict=on_conflict).execute()
+    else:
+        resp = req.upsert(payload).execute()
+    data = resp.data or []
+    return len(data) if isinstance(data, list) else 1
+
+
+def main() -> None:
+    model_version = MODEL_VERSION or f"auto-{datetime.now().strftime('%Y%m%d')}"
+    pulled_at = _utc_now()
+
+    sb = _load_supabase()
+    scoreboard = fetch_scoreboard()
+    if scoreboard.empty:
+        raise RuntimeError("No scoreboard data returned.")
+
+    raw_rows: List[Dict[str, object]] = []
+    team_rows: Dict[str, Dict[str, object]] = {}
+    game_rows: List[Dict[str, object]] = []
+    market_rows: List[Dict[str, object]] = []
+    dq_rows: List[Dict[str, object]] = []
+
+    game_id_set = set()
+    for _, row in scoreboard.iterrows():
+        external_game_id = str(row.get("game_id") or "").strip()
+        if not external_game_id:
+            continue
+
+        status, reasons = _validate_game(row.to_dict())
+        if status != "verified":
+            dq_rows.append(
+                {
+                    "entity_type": "games",
+                    "entity_id": None,
+                    "severity": "warning" if status == "partial" else "error",
+                    "reason_codes": reasons,
+                    "details": {"external_game_id": external_game_id},
+                }
+            )
+
+        raw_rows.append(
+            {
+                "season": SEASON,
+                "source": SOURCE,
+                "external_game_id": external_game_id,
+                "payload": _sanitize_payload(row.to_dict()),
+                "pulled_at": _iso(pulled_at),
+                "verification_status": status,
+                "verification_notes": "|".join(reasons),
+            }
+        )
+
+        home_team = row.get("home_team")
+        away_team = row.get("away_team")
+        if not home_team or not away_team:
+            continue
+
+        home_id = _uuid_for_team(SEASON, SOURCE, home_team)
+        away_id = _uuid_for_team(SEASON, SOURCE, away_team)
+        team_rows[home_id] = {
+            "id": home_id,
+            "season": SEASON,
+            "source_team_id": None,
+            "team_name": home_team,
+            "conference": None,
+        }
+        team_rows[away_id] = {
+            "id": away_id,
+            "season": SEASON,
+            "source_team_id": None,
+            "team_name": away_team,
+            "conference": None,
+        }
+
+        game_id = _uuid_for_game(SEASON, SOURCE, external_game_id)
+        game_datetime = _parse_game_datetime(row.to_dict())
+        if game_datetime is None:
+            continue
+        game_rows.append(
+            {
+                "id": game_id,
+                "season": SEASON,
+                "game_datetime_utc": game_datetime,
+                "home_team_id": home_id,
+                "away_team_id": away_id,
+                "home_score": _safe_num(row.get("home_score")),
+                "away_score": _safe_num(row.get("away_score")),
+                "status": "final" if row.get("completed") else "scheduled",
+                "venue": row.get("venue"),
+                "source": SOURCE,
+                "external_game_id": external_game_id,
+                "verification_status": status,
+            }
+        )
+        game_id_set.add(game_id)
+
+        market_rows.append(
+            {
+                "game_id": game_id,
+                "book": row.get("market_provider") or "espn",
+                "pulled_at": _iso(pulled_at),
+                "spread_home": _safe_num(row.get("market_spread")),
+                "total": _safe_num(row.get("market_total")),
+                "ml_home": _safe_num(row.get("market_home_ml")),
+                "ml_away": _safe_num(row.get("market_away_ml")),
+            }
+        )
+
+    counts = Counts(pulled=len(scoreboard), rejected=sum(1 for r in raw_rows if r["verification_status"] == "rejected"))
+
+    upsert_rows(sb, "raw", "raw_games", raw_rows, on_conflict="season,source,external_game_id")
+    upsert_rows(sb, "public", "teams", list(team_rows.values()), on_conflict="season,team_name")
+    counts = counts.__class__(
+        pulled=counts.pulled,
+        rejected=counts.rejected,
+        games_upserted=upsert_rows(sb, "public", "games", game_rows, on_conflict="season,source,external_game_id"),
+        markets_upserted=upsert_rows(sb, "public", "market_lines", market_rows, on_conflict="game_id,book,pulled_at"),
+        predictions_upserted=counts.predictions_upserted,
+    )
+
+    if dq_rows:
+        upsert_rows(sb, "public", "dq_audit", dq_rows)
+
+    preds = build_ml_outputs()
+    if preds.empty:
+        raise RuntimeError("No predictions generated.")
+
+    preds["event_id"] = preds["event_id"].astype(str)
+    scoreboard["game_id"] = scoreboard["game_id"].astype(str)
+    merged = preds.merge(scoreboard, left_on="event_id", right_on="game_id", how="left", suffixes=("", "_game"))
+
+    prediction_rows: List[Dict[str, object]] = []
+    for _, row in merged.iterrows():
+        external_game_id = str(row.get("event_id") or "").strip()
+        if not external_game_id:
+            continue
+        game_id = _uuid_for_game(SEASON, SOURCE, external_game_id)
+        if game_id not in game_id_set:
+            continue
+        pred_spread = _safe_num(row.get("pred_margin_home"))
+        pred_total = _safe_num(row.get("pred_total"))
+        market_spread = _safe_num(row.get("market_spread"))
+        market_total = _safe_num(row.get("market_total"))
+        edge_spread = pred_spread - market_spread if pred_spread is not None and market_spread is not None else None
+        edge_total = pred_total - market_total if pred_total is not None and market_total is not None else None
+        confidence = _confidence_from_edge(edge_spread)
+        bet_side = _bet_side(edge_spread)
+        bet_units = _bet_units(edge_spread)
+        prediction_rows.append(
+            {
+                "model_version": model_version,
+                "game_id": game_id,
+                "source": SOURCE,
+                "external_game_id": external_game_id,
+                "game_datetime_utc": row.get("game_datetime_utc") or row.get("game_datetime_utc_game"),
+                "home_team": row.get("team_home") or row.get("home_team"),
+                "away_team": row.get("team_away") or row.get("away_team"),
+                "pred_spread": pred_spread,
+                "pred_total": pred_total,
+                "win_prob_home": None,
+                "market_spread": market_spread,
+                "market_total": market_total,
+                "edge_spread": edge_spread,
+                "edge_total": edge_total,
+                "bet_side": bet_side,
+                "bet_units": bet_units if bet_units else None,
+                "bet_signal": bool(bet_side),
+                "confidence": confidence,
+                "notes": None,
+                "model_inputs": json.dumps({"row_hash": row.get("row_hash")}),
+            }
+        )
+
+    counts = counts.__class__(
+        pulled=counts.pulled,
+        rejected=counts.rejected,
+        games_upserted=counts.games_upserted,
+        markets_upserted=counts.markets_upserted,
+        predictions_upserted=upsert_rows(sb, "public", "predictions", prediction_rows, on_conflict="model_version,external_game_id"),
+    )
+
+    print(
+        json.dumps(
+            {
+                "pulled": counts.pulled,
+                "games_upserted": counts.games_upserted,
+                "markets_upserted": counts.markets_upserted,
+                "predictions_upserted": counts.predictions_upserted,
+                "rejected": counts.rejected,
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260301000000_add_prediction_pipeline_tables.sql
+++ b/supabase/migrations/20260301000000_add_prediction_pipeline_tables.sql
@@ -1,0 +1,163 @@
+create extension if not exists "pgcrypto";
+create schema if not exists raw;
+
+create table if not exists public.teams (
+  id uuid primary key default gen_random_uuid(),
+  season int not null,
+  source_team_id text null,
+  team_name text not null,
+  conference text null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (season, source_team_id),
+  unique (season, team_name)
+);
+
+create table if not exists raw.raw_games (
+  id uuid primary key default gen_random_uuid(),
+  season int not null,
+  source text not null,
+  external_game_id text not null,
+  payload jsonb not null,
+  pulled_at timestamptz not null,
+  verification_status text not null default 'partial',
+  verification_notes text null,
+  unique (season, source, external_game_id)
+);
+
+create table if not exists public.games (
+  id uuid primary key default gen_random_uuid(),
+  season int not null,
+  game_datetime_utc timestamptz not null,
+  home_team_id uuid not null references public.teams(id),
+  away_team_id uuid not null references public.teams(id),
+  home_score int null,
+  away_score int null,
+  status text not null default 'scheduled',
+  venue text null,
+  source text not null,
+  external_game_id text not null,
+  verification_status text not null default 'partial',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (season, source, external_game_id),
+  unique (season, game_datetime_utc, home_team_id, away_team_id)
+);
+
+create table if not exists public.market_lines (
+  id uuid primary key default gen_random_uuid(),
+  game_id uuid not null references public.games(id),
+  book text not null,
+  pulled_at timestamptz not null,
+  spread_home numeric null,
+  total numeric null,
+  ml_home int null,
+  ml_away int null,
+  unique (game_id, book, pulled_at)
+);
+
+create table if not exists public.team_game_features (
+  id uuid primary key default gen_random_uuid(),
+  game_id uuid not null references public.games(id),
+  team_id uuid not null references public.teams(id),
+  home_away text not null check (home_away in ('home', 'away')),
+  feature_set text not null,
+  features jsonb not null,
+  pulled_at timestamptz not null,
+  verification_status text not null default 'partial',
+  unique (game_id, team_id, feature_set)
+);
+
+create table if not exists public.predictions (
+  id uuid primary key default gen_random_uuid(),
+  model_version text not null,
+  created_at timestamptz not null default now(),
+  game_id uuid not null references public.games(id),
+  source text not null,
+  external_game_id text not null,
+  game_datetime_utc timestamptz not null,
+  home_team text not null,
+  away_team text not null,
+  pred_spread numeric null,
+  pred_total numeric null,
+  win_prob_home numeric null,
+  market_spread numeric null,
+  market_total numeric null,
+  edge_spread numeric null,
+  edge_total numeric null,
+  bet_side text null,
+  bet_units numeric null,
+  bet_signal boolean not null default false,
+  confidence numeric null,
+  notes text null,
+  model_inputs jsonb null,
+  unique (model_version, external_game_id)
+);
+
+create table if not exists public.dq_audit (
+  id uuid primary key default gen_random_uuid(),
+  entity_type text not null,
+  entity_id uuid null,
+  severity text not null,
+  reason_codes text[] not null,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_games_season_datetime on public.games (season, game_datetime_utc);
+create index if not exists idx_games_home_team on public.games (home_team_id);
+create index if not exists idx_games_away_team on public.games (away_team_id);
+
+create index if not exists idx_market_lines_game on public.market_lines (game_id);
+create index if not exists idx_market_lines_pulled_at on public.market_lines (pulled_at);
+
+create index if not exists idx_team_game_features_game on public.team_game_features (game_id);
+create index if not exists idx_team_game_features_team on public.team_game_features (team_id);
+
+create index if not exists idx_predictions_model_version on public.predictions (model_version);
+create index if not exists idx_predictions_game on public.predictions (game_id);
+
+create index if not exists idx_dq_audit_entity on public.dq_audit (entity_type);
+
+alter table public.teams enable row level security;
+alter table raw.raw_games enable row level security;
+alter table public.games enable row level security;
+alter table public.market_lines enable row level security;
+alter table public.team_game_features enable row level security;
+alter table public.predictions enable row level security;
+alter table public.dq_audit enable row level security;
+
+drop policy if exists teams_read on public.teams;
+create policy teams_read on public.teams
+for select to authenticated
+using (true);
+
+drop policy if exists raw_games_read on raw.raw_games;
+create policy raw_games_read on raw.raw_games
+for select to authenticated
+using (true);
+
+drop policy if exists games_read on public.games;
+create policy games_read on public.games
+for select to authenticated
+using (true);
+
+drop policy if exists market_lines_read on public.market_lines;
+create policy market_lines_read on public.market_lines
+for select to authenticated
+using (true);
+
+drop policy if exists team_game_features_read on public.team_game_features;
+create policy team_game_features_read on public.team_game_features
+for select to authenticated
+using (true);
+
+drop policy if exists predictions_read on public.predictions;
+create policy predictions_read on public.predictions
+for select to authenticated
+using (true);
+
+drop policy if exists dq_audit_read on public.dq_audit;
+create policy dq_audit_read on public.dq_audit
+for select to authenticated
+using (true);


### PR DESCRIPTION
### Motivation
- Provide an automated daily pipeline to pull ESPN scoreboard data, run models, compute edges vs. Vegas, and persist predictions to Supabase for downstream UIs and tracking.  
- Add production-safe schema, indexes and RLS for raw, canonical, market, features, predictions and data-quality audit storage.  
- Expose quick product surfaces: a Daily Dashboard and Model Reports in Streamlit and a local ensemble optimizer to tune ensemble weights.

### Description
- Added Supabase migration `supabase/migrations/20260301000000_add_prediction_pipeline_tables.sql` that creates `public.teams`, `raw.raw_games`, `public.games`, `public.market_lines`, `public.team_game_features`, `public.predictions`, and `public.dq_audit` with uniqueness constraints, indexes and RLS policies (authenticated read).  
- Implemented `scripts/daily_auto_predict.py` which: pulls ESPN scoreboard rows, validates & records verification_status, writes raw rows to `raw.raw_games`, upserts teams/games/market_lines, runs the feature builder + ML prediction (`ml.feature_matrix` + `ml.predict_ml`), computes edges/bet signals and upserts to `public.predictions`, and writes `dq_audit` rows for partial/rejected items.  
- Added Streamlit multipage UI pages `pages/1_Daily_Dashboard.py` and `pages/2_Model_Reports.py` to view today’s games/edges and leaderboards/ROI respectively (fallback to `ml/predictions_latest.csv` when Supabase creds are absent).  
- Added a GitHub Actions schedule `.github/workflows/daily_auto_predict.yml` to run the pipeline daily and `ml/optimize_ensemble.py` to grid-search ensemble weights from historical predictions.

### Testing
- Committed changes: `git commit` completed successfully and new files were added. (succeeded)  
- Local data inspection: ran a small Python read of `espn_games.csv` to verify scoreboard CSVs are present and readable. (succeeded)  
- UI smoke-start: attempted `streamlit run streamlit_app.py` to validate Streamlit pages, but the run failed with a `SyntaxError` in the existing `streamlit_app.py` (unrelated to the new `pages/` files) which blocks full UI verification; this must be fixed before end-to-end UI checks. (failed)  
- Playwright attempt to open the Daily Dashboard produced a screenshot artifact, but the underlying Streamlit compilation error prevents reliable runtime verification. (partial)

Notes: run `supabase db push` to apply the migration, then set GitHub Secrets (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) and run `python scripts/daily_auto_predict.py` to validate end-to-end ingestion and upserts; fix the `streamlit_app.py` SyntaxError before re-running the Streamlit UI checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698635019210832bb04dc523f7eb48f3)