### PR TITLE
Pack ESPN team-game features into JSON payload to avoid row-size errors

### DIFF
--- a/load_csv_to_db.py
+++ b/load_csv_to_db.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import csv
+import json
 import hashlib
 import os
 import re
@@ -32,6 +33,15 @@ LOAD_MODE = (os.getenv("LOAD_MODE") or "replace").strip().lower()
 AUTO_ADD_COLUMN_ALLOWLIST = {
     ("raw", "espn_team_game_features"),
     ("raw", "espn_matchups_model_ready"),
+}
+
+# Optional: pack wide feature CSVs into a single JSON column to avoid Postgres row-size limits.
+PACK_FEATURES_JSON = (os.getenv("PACK_FEATURES_JSON") or "1").strip().lower() in ("1", "true", "yes")
+PACK_FEATURES_JSON_ALLOWLIST = {
+    ("raw", "espn_team_game_features"),
+}
+PACK_FEATURES_BASE_COLS = {
+    "espn_team_game_features": ["row_hash", "event_id", "team_id", "team", "home_away", "game_datetime_utc"],
 }
 
 # Basic retry (helps with transient network issues)
@@ -371,6 +381,50 @@ def _prepare_csv_for_load(local_path: Path, table_name: str) -> Path:
     return tmp
 
 
+def _pack_features_json(local_path: Path, table_name: str, base_cols: List[str]) -> Path:
+    cols = _read_csv_header_columns(local_path)
+    _validate_csv_header(cols, local_path)
+
+    missing_base = [c for c in base_cols if c not in cols]
+    if missing_base:
+        raise ValueError(f"{local_path.name}: missing base columns required for packing: {missing_base}")
+
+    extra_cols = [c for c in cols if c not in base_cols]
+    if not extra_cols:
+        return local_path
+
+    idx = {c: i for i, c in enumerate(cols)}
+    tmp = Path(tempfile.mkstemp(prefix=f"loadpack_{table_name}_", suffix=".csv")[1])
+
+    with local_path.open("r", encoding="utf-8", errors="replace", newline="") as fin, tmp.open(
+        "w", encoding="utf-8", newline=""
+    ) as fout:
+        reader = csv.reader(fin)
+        writer = csv.writer(fout)
+
+        try:
+            header = next(reader)
+        except StopIteration:
+            return local_path
+
+        writer.writerow(base_cols + ["features"])
+        for row in reader:
+            if len(row) < len(header):
+                row = row + [""] * (len(header) - len(row))
+
+            payload = {}
+            for col in extra_cols:
+                raw = row[idx[col]]
+                if _normalize_str(raw) == "":
+                    continue
+                payload[col] = raw
+
+            base_values = [row[idx[c]] if idx.get(c) is not None else "" for c in base_cols]
+            writer.writerow(base_values + [json.dumps(payload, separators=(",", ":"), ensure_ascii=False)])
+
+    return tmp
+
+
 def _copy_csv_into_table(conn: psycopg.Connection, qualified_table: str, local_path: Path) -> None:
     cols = _read_csv_header_columns(local_path)
     _validate_csv_header(cols, local_path)
@@ -537,22 +591,40 @@ def load_one(local_path: str, table_name: str) -> None:
             time.sleep(delay)
 
         tmp_path: Optional[Path] = None
+        packed_path: Optional[Path] = None
         try:
-            prepared = _prepare_csv_for_load(lp, table_name)
-            tmp_path = prepared if prepared != lp else None
-            validation_result = _preflight_validate_csv(prepared, table_name)
-
-            # Skip empty files
-            if validation_result.get("empty", False):
-                print(f"[SKIP] {local_path} is empty (zero data rows)")
-                return
-
             with psycopg.connect(SUPABASE_DB_URL, autocommit=False) as conn:
                 if not _check_table_exists(conn, DB_SCHEMA, table_name):
                     _die(
                         f"Destination table missing: {DB_SCHEMA}.{table_name}\n"
                         f"Create it in Supabase first (SQL Editor)."
                     )
+
+                table_cols = _get_table_columns(conn, DB_SCHEMA, table_name)
+
+                prepared = _prepare_csv_for_load(lp, table_name)
+                tmp_path = prepared if prepared != lp else None
+
+                if (
+                    PACK_FEATURES_JSON
+                    and (DB_SCHEMA, table_name) in PACK_FEATURES_JSON_ALLOWLIST
+                ):
+                    base_cols = PACK_FEATURES_BASE_COLS.get(table_name, [])
+                    if "features" not in table_cols:
+                        raise ValueError(
+                            f"{DB_SCHEMA}.{table_name} is missing a 'features' jsonb column required for "
+                            f"PACK_FEATURES_JSON. Apply the migration and rerun."
+                        )
+                    packed = _pack_features_json(prepared, table_name, base_cols)
+                    packed_path = packed if packed != prepared else None
+                    prepared = packed
+
+                validation_result = _preflight_validate_csv(prepared, table_name)
+
+                # Skip empty files
+                if validation_result.get("empty", False):
+                    print(f"[SKIP] {local_path} is empty (zero data rows)")
+                    return
 
                 if LOAD_MODE == "replace":
                     csv_cols = _read_csv_header_columns(prepared)
@@ -601,6 +673,11 @@ def load_one(local_path: str, table_name: str) -> None:
             if tmp_path and tmp_path.exists():
                 try:
                     tmp_path.unlink()
+                except Exception:
+                    pass
+            if packed_path and packed_path.exists():
+                try:
+                    packed_path.unlink()
                 except Exception:
                     pass
 

--- a/ml/feature_matrix.py
+++ b/ml/feature_matrix.py
@@ -123,8 +123,40 @@ def _load_features_from_db(schema: str, table: str) -> pd.DataFrame:
     with psycopg.connect(SUPABASE_DB_URL) as conn:
         df = pd.read_sql(sql, conn)
 
+    df = _expand_features_json(df)
     print(f"[INFO] Loaded features from DB: {schema}.{table} rows={len(df)} cols={len(df.columns)}")
     return df
+
+
+def _parse_features_cell(value: object) -> Dict[str, object]:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+    return {}
+
+
+def _expand_features_json(df: pd.DataFrame) -> pd.DataFrame:
+    if "features" not in df.columns:
+        return df
+
+    base_df = df.drop(columns=["features"])
+    feature_series = df["features"].apply(_parse_features_cell)
+    features_df = pd.json_normalize(feature_series)
+
+    overlap = set(base_df.columns).intersection(features_df.columns)
+    if overlap:
+        features_df = features_df.drop(columns=list(overlap))
+
+    expanded = pd.concat([base_df.reset_index(drop=True), features_df.reset_index(drop=True)], axis=1)
+    print(f"[INFO] Expanded features json: +{len(features_df.columns)} cols")
+    return expanded
 
 
 def _load_features_from_csv(path: Path) -> pd.DataFrame:

--- a/supabase/migrations/20260305000000_add_features_json_to_raw.sql
+++ b/supabase/migrations/20260305000000_add_features_json_to_raw.sql
@@ -1,0 +1,6 @@
+-- Add JSONB feature payload column to avoid row-size limits for wide feature tables.
+alter table if exists raw.espn_team_game_features
+  add column if not exists features jsonb;
+
+comment on column raw.espn_team_game_features.features is
+  'Packed feature payload for wide ESPN team-game features (JSONB).';


### PR DESCRIPTION
### Motivation
- Ingestion was failing with `row is too big` when loading `espn_team_game_features.csv` into Postgres due to very wide feature CSVs exceeding Postgres row-size limits.
- Need a small, safe change to avoid row-size failures while preserving provenance and allowing downstream ML code to expand packed features.

### Description
- Added optional JSON packing behavior behind `PACK_FEATURES_JSON` (env) and an allowlist so only wide raw feature tables are affected, with base columns preserved and extras moved into a `features` JSON payload; implemented in `load_csv_to_db.py` via `_pack_features_json` and callers in `load_one`.
- Enforced that `raw.espn_team_game_features` must have a `features` jsonb column when packing is enabled and added a SQL migration `supabase/migrations/20260305000000_add_features_json_to_raw.sql` to create that column.
- Updated ML pipeline in `ml/feature_matrix.py` to expand/unpack the `features` JSON payload returned from the DB into dataframe columns so existing feature processing continues to work.
- Minimal, targeted edits: `load_csv_to_db.py` (packing + env flags + cleanup), `ml/feature_matrix.py` (expand JSON), and one migration SQL file to add `features jsonb`.

### Testing
- No automated tests were executed as part of this change (no test suite run in this rollout).
- Recommended automated checks to run next: run the ingestion with `PACK_FEATURES_JSON=1 LOAD_MODE=upsert UPLOAD_GROUP=espn SUPABASE_DB_URL=<url>` and assert the load completes; run ML feature builder `python -m ml.feature_matrix` (or equivalent) against the DB and assert features expanded; both should return success without row-size errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988230f088c832b808bb54fc5d9cd74)