### PR TITLE
Add team_boxscores/team_metrics migrations and audit script; fix missing pulled_at

### DIFF
--- a/scripts/audit_supabase_ingestion.py
+++ b/scripts/audit_supabase_ingestion.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Audit Supabase ingestion tables for expected data presence.
+
+Purpose:
+- Detect when raw ingestion tables are populated but normalized/public tables are empty.
+- Surface missing tables so you can create migrations intentionally.
+
+Requires:
+- SUPABASE_DB_URL
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple
+
+import psycopg
+
+SUPABASE_DB_URL = (os.getenv("SUPABASE_DB_URL") or "").strip()
+
+RAW_TABLES = [
+    ("raw", "espn_games"),
+    ("raw", "espn_team_game_logs"),
+    ("raw", "espn_team_game_features"),
+    ("raw", "espn_matchups_model_ready"),
+    ("raw", "predictions_latest"),
+]
+
+PUBLIC_TABLES = [
+    ("public", "team_game_features"),
+    ("public", "team_metrics"),
+    ("public", "team_boxscores"),
+]
+
+PAIR_CHECKS = [
+    (("raw", "espn_team_game_features"), ("public", "team_game_features")),
+    (("raw", "espn_team_game_logs"), ("public", "team_boxscores")),
+]
+
+
+@dataclass(frozen=True)
+class TableStatus:
+    schema: str
+    table: str
+    exists: bool
+    rows: Optional[int] = None
+
+
+def _die(msg: str) -> None:
+    print(f"[ERROR] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _table_exists(conn: psycopg.Connection, schema: str, table: str) -> bool:
+    q = """
+    select 1
+    from information_schema.tables
+    where table_schema = %s and table_name = %s
+    limit 1
+    """
+    with conn.cursor() as cur:
+        cur.execute(q, (schema, table))
+        return cur.fetchone() is not None
+
+
+def _row_count(conn: psycopg.Connection, schema: str, table: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(f"select count(*) from {schema}.{table};")
+        return int(cur.fetchone()[0])
+
+
+def _scan_tables(conn: psycopg.Connection, tables: Iterable[Tuple[str, str]]) -> List[TableStatus]:
+    statuses: List[TableStatus] = []
+    for schema, table in tables:
+        exists = _table_exists(conn, schema, table)
+        rows = _row_count(conn, schema, table) if exists else None
+        statuses.append(TableStatus(schema=schema, table=table, exists=exists, rows=rows))
+    return statuses
+
+
+def _find_status(statuses: List[TableStatus], schema: str, table: str) -> Optional[TableStatus]:
+    for status in statuses:
+        if status.schema == schema and status.table == table:
+            return status
+    return None
+
+
+def _print_statuses(title: str, statuses: List[TableStatus]) -> None:
+    print(f"\n== {title} ==")
+    for status in statuses:
+        if not status.exists:
+            print(f"[MISSING] {status.schema}.{status.table}")
+            continue
+        rows = status.rows if status.rows is not None else 0
+        label = "empty" if rows == 0 else "rows"
+        print(f"[OK] {status.schema}.{status.table}: {rows} {label}")
+
+
+def _print_pair_warnings(statuses: List[TableStatus]) -> None:
+    print("\n== Cross-table checks ==")
+    any_warning = False
+    for (raw_schema, raw_table), (pub_schema, pub_table) in PAIR_CHECKS:
+        raw_status = _find_status(statuses, raw_schema, raw_table)
+        pub_status = _find_status(statuses, pub_schema, pub_table)
+        if not raw_status or not pub_status:
+            continue
+        if raw_status.exists and pub_status.exists:
+            raw_rows = raw_status.rows or 0
+            pub_rows = pub_status.rows or 0
+            if raw_rows > 0 and pub_rows == 0:
+                any_warning = True
+                print(
+                    f"[WARN] {raw_schema}.{raw_table} has data ({raw_rows} rows) but "
+                    f"{pub_schema}.{pub_table} is empty."
+                )
+    if not any_warning:
+        print("[OK] No raw/public mismatches detected.")
+
+
+def main() -> None:
+    if not SUPABASE_DB_URL:
+        _die("SUPABASE_DB_URL is missing/empty.")
+
+    with psycopg.connect(SUPABASE_DB_URL) as conn:
+        raw_statuses = _scan_tables(conn, RAW_TABLES)
+        public_statuses = _scan_tables(conn, PUBLIC_TABLES)
+
+    all_statuses = raw_statuses + public_statuses
+
+    _print_statuses("Raw ingestion tables", raw_statuses)
+    _print_statuses("Public/model tables", public_statuses)
+    _print_pair_warnings(all_statuses)
+
+    print("\nNext steps:")
+    print("- If public tables are missing, add a migration to create them.")
+    print("- If public tables exist but are empty, add a normalization step to map raw -> public.")
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260306000000_add_team_boxscores_and_metrics.sql
+++ b/supabase/migrations/20260306000000_add_team_boxscores_and_metrics.sql
@@ -1,0 +1,48 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.team_boxscores (
+  id uuid primary key default gen_random_uuid(),
+  game_id uuid not null references public.games(id),
+  team_id uuid not null references public.teams(id),
+  home_away text not null check (home_away in ('home', 'away')),
+  source text not null default 'espn',
+  pulled_at timestamptz not null default now(),
+  stats jsonb not null default '{}'::jsonb,
+  verification_status text not null default 'partial',
+  verification_notes text null,
+  unique (game_id, team_id)
+);
+
+create table if not exists public.team_metrics (
+  id uuid primary key default gen_random_uuid(),
+  season int not null,
+  team_id uuid not null references public.teams(id),
+  metric_set text not null,
+  source text not null default 'espn',
+  pulled_at timestamptz not null default now(),
+  metrics jsonb not null default '{}'::jsonb,
+  verification_status text not null default 'partial',
+  verification_notes text null,
+  unique (season, team_id, metric_set)
+);
+
+create index if not exists idx_team_boxscores_game on public.team_boxscores (game_id);
+create index if not exists idx_team_boxscores_team on public.team_boxscores (team_id);
+create index if not exists idx_team_boxscores_pulled_at on public.team_boxscores (pulled_at);
+
+create index if not exists idx_team_metrics_team on public.team_metrics (team_id);
+create index if not exists idx_team_metrics_season on public.team_metrics (season);
+create index if not exists idx_team_metrics_pulled_at on public.team_metrics (pulled_at);
+
+alter table public.team_boxscores enable row level security;
+alter table public.team_metrics enable row level security;
+
+drop policy if exists team_boxscores_read on public.team_boxscores;
+create policy team_boxscores_read on public.team_boxscores
+for select to authenticated
+using (true);
+
+drop policy if exists team_metrics_read on public.team_metrics;
+create policy team_metrics_read on public.team_metrics
+for select to authenticated
+using (true);

--- a/supabase/migrations/20260306001000_fix_team_boxscores_metrics_pulled_at.sql
+++ b/supabase/migrations/20260306001000_fix_team_boxscores_metrics_pulled_at.sql
@@ -1,0 +1,8 @@
+alter table public.team_boxscores
+  add column if not exists pulled_at timestamptz not null default now();
+
+alter table public.team_metrics
+  add column if not exists pulled_at timestamptz not null default now();
+
+create index if not exists idx_team_boxscores_pulled_at on public.team_boxscores (pulled_at);
+create index if not exists idx_team_metrics_pulled_at on public.team_metrics (pulled_at);


### PR DESCRIPTION
### Motivation
- Ensure normalized team tables exist and are queryable and to surface a previously failing migration error `column "pulled_at" does not exist`.
- Provide a lightweight diagnostic to detect when raw ingestion tables have data but normalized/public tables are empty so pipeline issues are easier to find.

### Description
- Add `supabase/migrations/20260306000000_add_team_boxscores_and_metrics.sql` which creates `public.team_boxscores` and `public.team_metrics` with primary keys, foreign keys to `public.games`/`public.teams`, uniqueness constraints, indexes, `pulled_at` defaults, and RLS read policies for authenticated users.
- Add `scripts/audit_supabase_ingestion.py`, a small `psycopg`-based diagnostic that reports existence and row counts for key `raw.*` and `public.*` tables and warns when raw tables contain rows but corresponding public tables are empty.
- Add a follow-up migration `supabase/migrations/20260306001000_fix_team_boxscores_metrics_pulled_at.sql` that safely adds `pulled_at timestamptz not null default now()` to both tables (using `IF NOT EXISTS`) and creates indexes on `pulled_at` to resolve the runtime error.

### Testing
- No automated tests were run; these are SQL migrations and a diagnostic script, so apply the migrations in Supabase and run the audit script for verification.
- The fix migration is idempotent (`ADD COLUMN IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS`) and should run without error when applied to the target database.
- Manual verification steps: apply migrations and run the audit script with `SUPABASE_DB_URL` set; expect `pulled_at` to appear in both `team_boxscores` and `team_metrics` and the audit script to report table existence and row counts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698975403668832b8547b60584aa958e)