### PR TITLE
Align public.teams schema with model (add season, source_team_id, indexes)

### DIFF
--- a/.github/workflows/audit_supabase_ingestion.yml
+++ b/.github/workflows/audit_supabase_ingestion.yml
@@ -1,0 +1,27 @@
+name: audit-supabase-ingestion
+
+on:
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run audit script
+        run: |
+          python scripts/audit_supabase_ingestion.py

--- a/.github/workflows/normalize_supabase.yml
+++ b/.github/workflows/normalize_supabase.yml
@@ -1,0 +1,43 @@
+name: normalize-supabase
+
+on:
+  workflow_dispatch:
+    inputs:
+      season:
+        description: "Season year (e.g., 2025)"
+        required: false
+        default: "2025"
+      source:
+        description: "Source name (default: espn)"
+        required: false
+        default: "espn"
+      feature_set:
+        description: "Feature set label for team_game_features"
+        required: false
+        default: "espn_v1"
+
+jobs:
+  normalize:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+      SEASON: ${{ github.event.inputs.season }}
+      SOURCE: ${{ github.event.inputs.source }}
+      FEATURE_SET: ${{ github.event.inputs.feature_set }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run normalization script
+        run: |
+          python scripts/normalize_raw_to_public.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ html5lib==1.1
 beautifulsoup4==4.12.3
 requests
 supabase
+psycopg
 python-dotenv
 python-dateutil

--- a/scripts/audit_supabase_ingestion.py
+++ b/scripts/audit_supabase_ingestion.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Audit Supabase ingestion tables for expected data presence.
+
+Purpose:
+- Detect when raw ingestion tables are populated but normalized/public tables are empty.
+- Surface missing tables so you can create migrations intentionally.
+
+Requires:
+- SUPABASE_DB_URL
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Tuple
+
+import psycopg
+
+SUPABASE_DB_URL = (os.getenv("SUPABASE_DB_URL") or "").strip()
+
+RAW_TABLES = [
+    ("raw", "espn_games"),
+    ("raw", "espn_team_game_logs"),
+    ("raw", "espn_team_game_features"),
+    ("raw", "espn_matchups_model_ready"),
+    ("raw", "predictions_latest"),
+]
+
+PUBLIC_TABLES = [
+    ("public", "team_game_features"),
+    ("public", "team_metrics"),
+    ("public", "team_boxscores"),
+]
+
+PAIR_CHECKS = [
+    (("raw", "espn_team_game_features"), ("public", "team_game_features")),
+    (("raw", "espn_team_game_logs"), ("public", "team_boxscores")),
+]
+
+
+@dataclass(frozen=True)
+class TableStatus:
+    schema: str
+    table: str
+    exists: bool
+    rows: Optional[int] = None
+
+
+def _die(msg: str) -> None:
+    print(f"[ERROR] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _table_exists(conn: psycopg.Connection, schema: str, table: str) -> bool:
+    q = """
+    select 1
+    from information_schema.tables
+    where table_schema = %s and table_name = %s
+    limit 1
+    """
+    with conn.cursor() as cur:
+        cur.execute(q, (schema, table))
+        return cur.fetchone() is not None
+
+
+def _row_count(conn: psycopg.Connection, schema: str, table: str) -> int:
+    with conn.cursor() as cur:
+        cur.execute(f"select count(*) from {schema}.{table};")
+        return int(cur.fetchone()[0])
+
+
+def _scan_tables(conn: psycopg.Connection, tables: Iterable[Tuple[str, str]]) -> List[TableStatus]:
+    statuses: List[TableStatus] = []
+    for schema, table in tables:
+        exists = _table_exists(conn, schema, table)
+        rows = _row_count(conn, schema, table) if exists else None
+        statuses.append(TableStatus(schema=schema, table=table, exists=exists, rows=rows))
+    return statuses
+
+
+def _find_status(statuses: List[TableStatus], schema: str, table: str) -> Optional[TableStatus]:
+    for status in statuses:
+        if status.schema == schema and status.table == table:
+            return status
+    return None
+
+
+def _print_statuses(title: str, statuses: List[TableStatus]) -> None:
+    print(f"\n== {title} ==")
+    for status in statuses:
+        if not status.exists:
+            print(f"[MISSING] {status.schema}.{status.table}")
+            continue
+        rows = status.rows if status.rows is not None else 0
+        label = "empty" if rows == 0 else "rows"
+        print(f"[OK] {status.schema}.{status.table}: {rows} {label}")
+
+
+def _print_pair_warnings(statuses: List[TableStatus]) -> None:
+    print("\n== Cross-table checks ==")
+    any_warning = False
+    for (raw_schema, raw_table), (pub_schema, pub_table) in PAIR_CHECKS:
+        raw_status = _find_status(statuses, raw_schema, raw_table)
+        pub_status = _find_status(statuses, pub_schema, pub_table)
+        if not raw_status or not pub_status:
+            continue
+        if raw_status.exists and pub_status.exists:
+            raw_rows = raw_status.rows or 0
+            pub_rows = pub_status.rows or 0
+            if raw_rows > 0 and pub_rows == 0:
+                any_warning = True
+                print(
+                    f"[WARN] {raw_schema}.{raw_table} has data ({raw_rows} rows) but "
+                    f"{pub_schema}.{pub_table} is empty."
+                )
+    if not any_warning:
+        print("[OK] No raw/public mismatches detected.")
+
+
+def main() -> None:
+    if not SUPABASE_DB_URL:
+        _die("SUPABASE_DB_URL is missing/empty.")
+
+    with psycopg.connect(SUPABASE_DB_URL) as conn:
+        raw_statuses = _scan_tables(conn, RAW_TABLES)
+        public_statuses = _scan_tables(conn, PUBLIC_TABLES)
+
+    all_statuses = raw_statuses + public_statuses
+
+    _print_statuses("Raw ingestion tables", raw_statuses)
+    _print_statuses("Public/model tables", public_statuses)
+    _print_pair_warnings(all_statuses)
+
+    print("\nNext steps:")
+    print("- If public tables are missing, add a migration to create them.")
+    print("- If public tables exist but are empty, add a normalization step to map raw -> public.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/normalize_raw_to_public.py
+++ b/scripts/normalize_raw_to_public.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+Normalize raw ESPN ingestion tables into public model tables.
+
+Targets:
+- public.teams
+- public.games
+- public.team_boxscores
+- public.team_game_features
+- public.dq_audit (for data quality issues)
+
+Requires:
+- SUPABASE_DB_URL
+
+Behavior:
+- Idempotent upserts with deterministic conflict keys.
+- Logs counts for pulled/upserted/rejected.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence
+
+import psycopg
+
+SUPABASE_DB_URL = (os.getenv("SUPABASE_DB_URL") or "").strip()
+SEASON = int(os.getenv("SEASON", "2025"))
+SOURCE = (os.getenv("SOURCE", "espn").strip().lower() or "espn")
+FEATURE_SET = (os.getenv("FEATURE_SET", "espn_v1").strip() or "espn_v1")
+
+RAW_SCHEMA = (os.getenv("RAW_SCHEMA", "raw").strip() or "raw")
+RAW_LOGS_TABLE = (os.getenv("RAW_LOGS_TABLE", "espn_team_game_logs").strip() or "espn_team_game_logs")
+RAW_FEATURES_TABLE = (os.getenv("RAW_FEATURES_TABLE", "espn_team_game_features").strip() or "espn_team_game_features")
+
+
+@dataclass(frozen=True)
+class Counts:
+    pulled: int = 0
+    upserted: int = 0
+    rejected: int = 0
+
+
+def _die(msg: str) -> None:
+    print(f"[ERROR] {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _has_column(conn: psycopg.Connection, schema: str, table: str, column: str) -> bool:
+    q = """
+    select 1
+    from information_schema.columns
+    where table_schema = %s and table_name = %s and column_name = %s
+    limit 1
+    """
+    with conn.cursor() as cur:
+        cur.execute(q, (schema, table, column))
+        return cur.fetchone() is not None
+
+
+def _pick_existing_column(conn: psycopg.Connection, schema: str, table: str, candidates: Sequence[str]) -> Optional[str]:
+    for col in candidates:
+        if _has_column(conn, schema, table, col):
+            return col
+    return None
+
+
+def _exec_rowcount(conn: psycopg.Connection, sql: str, params: Optional[Iterable[object]] = None) -> int:
+    with conn.cursor() as cur:
+        cur.execute(sql, params or ())
+        return cur.rowcount
+
+
+def _count_rows(conn: psycopg.Connection, sql: str, params: Optional[Iterable[object]] = None) -> int:
+    with conn.cursor() as cur:
+        cur.execute(sql, params or ())
+        return int(cur.fetchone()[0])
+
+
+def _insert_dq(conn: psycopg.Connection, entity_type: str, reason_codes: List[str], details: dict) -> int:
+    sql = """
+    insert into public.dq_audit (id, entity_type, entity_id, severity, reason_codes, details, created_at)
+    values (%s, %s, null, %s, %s, %s::jsonb, now())
+    """
+    severity = "error"
+    return _exec_rowcount(conn, sql, (str(uuid.uuid4()), entity_type, severity, reason_codes, json_dump(details)))
+
+
+def json_dump(obj: dict) -> str:
+    import json
+
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def upsert_teams(conn: psycopg.Connection, pulled_at_col: Optional[str]) -> Counts:
+    pulled = _count_rows(
+        conn,
+        f"""
+        select count(distinct team_id)
+        from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+        where team_id is not null and team is not null
+        """,
+    )
+
+    sql = f"""
+    insert into public.teams (season, source_team_id, team_name, conference, created_at, updated_at)
+    select distinct
+      %s as season,
+      team_id as source_team_id,
+      team as team_name,
+      null as conference,
+      now() as created_at,
+      now() as updated_at
+    from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+    where team_id is not null and team is not null
+    on conflict (season, source_team_id)
+    do update set team_name = excluded.team_name,
+                  updated_at = now();
+    """
+    upserted = _exec_rowcount(conn, sql, (SEASON,))
+    return Counts(pulled=pulled, upserted=upserted, rejected=0)
+
+
+def upsert_games(conn: psycopg.Connection) -> Counts:
+    pulled = _count_rows(
+        conn,
+        f"""
+        select count(distinct event_id)
+        from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+        where event_id is not null
+        """,
+    )
+
+    sql = f"""
+    with home as (
+      select
+        event_id,
+        team_id as home_source_team_id,
+        game_datetime_utc,
+        venue,
+        completed,
+        points_for as home_score,
+        points_against as away_score
+      from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+      where lower(home_away) = 'home'
+    ),
+    away as (
+      select
+        event_id,
+        team_id as away_source_team_id
+      from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+      where lower(home_away) = 'away'
+    ),
+    joined as (
+      select
+        h.event_id,
+        h.game_datetime_utc,
+        h.venue,
+        h.completed,
+        h.home_score,
+        h.away_score,
+        h.home_source_team_id,
+        a.away_source_team_id
+      from home h
+      join away a on a.event_id = h.event_id
+    )
+    insert into public.games (
+      season,
+      game_datetime_utc,
+      home_team_id,
+      away_team_id,
+      home_score,
+      away_score,
+      status,
+      venue,
+      source,
+      external_game_id,
+      verification_status,
+      created_at,
+      updated_at
+    )
+    select
+      %s as season,
+      j.game_datetime_utc,
+      ht.id as home_team_id,
+      at.id as away_team_id,
+      case when j.completed then j.home_score else null end as home_score,
+      case when j.completed then j.away_score else null end as away_score,
+      case when j.completed then 'final' else 'scheduled' end as status,
+      j.venue,
+      %s as source,
+      j.event_id as external_game_id,
+      case when j.completed then 'verified' else 'partial' end as verification_status,
+      now(),
+      now()
+    from joined j
+    join public.teams ht
+      on ht.season = %s and ht.source_team_id = j.home_source_team_id
+    join public.teams at
+      on at.season = %s and at.source_team_id = j.away_source_team_id
+    where j.game_datetime_utc is not null
+    on conflict (season, source, external_game_id)
+    do update set
+      game_datetime_utc = excluded.game_datetime_utc,
+      home_team_id = excluded.home_team_id,
+      away_team_id = excluded.away_team_id,
+      home_score = excluded.home_score,
+      away_score = excluded.away_score,
+      status = excluded.status,
+      venue = excluded.venue,
+      verification_status = excluded.verification_status,
+      updated_at = now();
+    """
+    upserted = _exec_rowcount(conn, sql, (SEASON, SOURCE, SEASON, SEASON))
+
+    rejected = 0
+    rejected += _exec_rowcount(
+        conn,
+        f"""
+        insert into public.dq_audit (id, entity_type, entity_id, severity, reason_codes, details, created_at)
+        select gen_random_uuid(), 'games', null, 'error', array['missing_game_datetime'],
+               jsonb_build_object('event_id', event_id), now()
+        from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+        where event_id is not null and game_datetime_utc is null
+        on conflict do nothing;
+        """,
+    )
+
+    rejected += _exec_rowcount(
+        conn,
+        f"""
+        with home as (
+          select event_id, team_id as home_source_team_id
+          from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+          where lower(home_away) = 'home'
+        ),
+        away as (
+          select event_id, team_id as away_source_team_id
+          from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+          where lower(home_away) = 'away'
+        ),
+        joined as (
+          select h.event_id, h.home_source_team_id, a.away_source_team_id
+          from home h
+          join away a on a.event_id = h.event_id
+        )
+        insert into public.dq_audit (id, entity_type, entity_id, severity, reason_codes, details, created_at)
+        select gen_random_uuid(), 'games', null, 'error', array['missing_team_mapping'],
+               jsonb_build_object('event_id', j.event_id,
+                                  'home_source_team_id', j.home_source_team_id,
+                                  'away_source_team_id', j.away_source_team_id),
+               now()
+        from joined j
+        left join public.teams ht
+          on ht.season = {SEASON} and ht.source_team_id = j.home_source_team_id
+        left join public.teams at
+          on at.season = {SEASON} and at.source_team_id = j.away_source_team_id
+        where ht.id is null or at.id is null
+        on conflict do nothing;
+        """,
+    )
+
+    return Counts(pulled=pulled, upserted=upserted, rejected=rejected)
+
+
+def upsert_team_boxscores(conn: psycopg.Connection, pulled_at_col: Optional[str], has_data_ok: bool) -> Counts:
+    pulled = _count_rows(
+        conn,
+        f"""
+        select count(*)
+        from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+        where event_id is not null and team_id is not null
+        """,
+    )
+
+    pulled_at_expr = f"r.{pulled_at_col}" if pulled_at_col else "now()"
+    verification_expr = "'partial'"
+    if has_data_ok:
+        verification_expr = "case when r.data_ok then 'verified' else 'partial' end"
+
+    rejected = 0
+    rejected += _exec_rowcount(
+        conn,
+        f"""
+        insert into public.dq_audit (id, entity_type, entity_id, severity, reason_codes, details, created_at)
+        select gen_random_uuid(), 'team_boxscores', null, 'error', array['missing_home_away'],
+               jsonb_build_object('event_id', event_id, 'team_id', team_id), now()
+        from {RAW_SCHEMA}.{RAW_LOGS_TABLE}
+        where event_id is not null
+          and team_id is not null
+          and (home_away is null or btrim(home_away) = '')
+        on conflict do nothing;
+        """,
+    )
+
+    sql = f"""
+    insert into public.team_boxscores (
+      game_id,
+      team_id,
+      home_away,
+      source,
+      pulled_at,
+      stats,
+      verification_status,
+      verification_notes
+    )
+    select
+      g.id as game_id,
+      t.id as team_id,
+      lower(r.home_away) as home_away,
+      %s as source,
+      {pulled_at_expr} as pulled_at,
+      to_jsonb(r) as stats,
+      {verification_expr} as verification_status,
+      null as verification_notes
+    from {RAW_SCHEMA}.{RAW_LOGS_TABLE} r
+    join public.games g
+      on g.season = %s and g.source = %s and g.external_game_id = r.event_id
+    join public.teams t
+      on t.season = %s and t.source_team_id = r.team_id
+    where r.home_away is not null
+      and btrim(r.home_away) <> ''
+    on conflict (game_id, team_id)
+    do update set
+      home_away = excluded.home_away,
+      pulled_at = excluded.pulled_at,
+      stats = excluded.stats,
+      verification_status = excluded.verification_status,
+      verification_notes = excluded.verification_notes;
+    """
+    upserted = _exec_rowcount(conn, sql, (SOURCE, SEASON, SOURCE, SEASON))
+    return Counts(pulled=pulled, upserted=upserted, rejected=rejected)
+
+
+def upsert_team_game_features(conn: psycopg.Connection, pulled_at_col: Optional[str], has_features_col: bool) -> Counts:
+    pulled = _count_rows(
+        conn,
+        f"""
+        select count(*)
+        from {RAW_SCHEMA}.{RAW_FEATURES_TABLE}
+        where event_id is not null and team_id is not null
+        """,
+    )
+
+    if not has_features_col:
+        rejected = _insert_dq(
+            conn,
+            "team_game_features",
+            ["missing_features_column"],
+            {
+                "table": f"{RAW_SCHEMA}.{RAW_FEATURES_TABLE}",
+                "note": "Expected features jsonb column for normalization.",
+            },
+        )
+        return Counts(pulled=pulled, upserted=0, rejected=rejected)
+
+    pulled_at_expr = f"r.{pulled_at_col}" if pulled_at_col else "now()"
+
+    sql = f"""
+    insert into public.team_game_features (
+      game_id,
+      team_id,
+      home_away,
+      feature_set,
+      features,
+      pulled_at,
+      verification_status
+    )
+    select
+      g.id as game_id,
+      t.id as team_id,
+      lower(r.home_away) as home_away,
+      %s as feature_set,
+      r.features as features,
+      {pulled_at_expr} as pulled_at,
+      'partial' as verification_status
+    from {RAW_SCHEMA}.{RAW_FEATURES_TABLE} r
+    join public.games g
+      on g.season = %s and g.source = %s and g.external_game_id = r.event_id
+    join public.teams t
+      on t.season = %s and t.source_team_id = r.team_id
+    on conflict (game_id, team_id, feature_set)
+    do update set
+      home_away = excluded.home_away,
+      features = excluded.features,
+      pulled_at = excluded.pulled_at,
+      verification_status = excluded.verification_status;
+    """
+    upserted = _exec_rowcount(conn, sql, (FEATURE_SET, SEASON, SOURCE, SEASON))
+    return Counts(pulled=pulled, upserted=upserted, rejected=0)
+
+
+def main() -> None:
+    if not SUPABASE_DB_URL:
+        _die("SUPABASE_DB_URL is missing/empty.")
+
+    with psycopg.connect(SUPABASE_DB_URL) as conn:
+        pulled_at_logs = _pick_existing_column(conn, RAW_SCHEMA, RAW_LOGS_TABLE, ["pulled_at_utc", "pulled_at"])
+        pulled_at_features = _pick_existing_column(conn, RAW_SCHEMA, RAW_FEATURES_TABLE, ["pulled_at_utc", "pulled_at"])
+        has_data_ok = _has_column(conn, RAW_SCHEMA, RAW_LOGS_TABLE, "data_ok")
+        has_features_col = _has_column(conn, RAW_SCHEMA, RAW_FEATURES_TABLE, "features")
+
+        print("[STEP] Upsert teams")
+        counts = upsert_teams(conn, pulled_at_logs)
+        print(f"[OK] teams: pulled={counts.pulled} upserted={counts.upserted}")
+
+        print("[STEP] Upsert games")
+        counts = upsert_games(conn)
+        print(f"[OK] games: pulled={counts.pulled} upserted={counts.upserted} rejected={counts.rejected}")
+
+        print("[STEP] Upsert team_boxscores")
+        counts = upsert_team_boxscores(conn, pulled_at_logs, has_data_ok)
+        print(f"[OK] team_boxscores: pulled={counts.pulled} upserted={counts.upserted}")
+
+        print("[STEP] Upsert team_game_features")
+        counts = upsert_team_game_features(conn, pulled_at_features, has_features_col)
+        print(f"[OK] team_game_features: pulled={counts.pulled} upserted={counts.upserted} rejected={counts.rejected}")
+
+        conn.commit()
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/migrations/20260306000000_add_team_boxscores_and_metrics.sql
+++ b/supabase/migrations/20260306000000_add_team_boxscores_and_metrics.sql
@@ -1,0 +1,48 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists public.team_boxscores (
+  id uuid primary key default gen_random_uuid(),
+  game_id uuid not null references public.games(id),
+  team_id uuid not null references public.teams(id),
+  home_away text not null check (home_away in ('home', 'away')),
+  source text not null default 'espn',
+  pulled_at timestamptz not null default now(),
+  stats jsonb not null default '{}'::jsonb,
+  verification_status text not null default 'partial',
+  verification_notes text null,
+  unique (game_id, team_id)
+);
+
+create table if not exists public.team_metrics (
+  id uuid primary key default gen_random_uuid(),
+  season int not null,
+  team_id uuid not null references public.teams(id),
+  metric_set text not null,
+  source text not null default 'espn',
+  pulled_at timestamptz not null default now(),
+  metrics jsonb not null default '{}'::jsonb,
+  verification_status text not null default 'partial',
+  verification_notes text null,
+  unique (season, team_id, metric_set)
+);
+
+create index if not exists idx_team_boxscores_game on public.team_boxscores (game_id);
+create index if not exists idx_team_boxscores_team on public.team_boxscores (team_id);
+create index if not exists idx_team_boxscores_pulled_at on public.team_boxscores (pulled_at);
+
+create index if not exists idx_team_metrics_team on public.team_metrics (team_id);
+create index if not exists idx_team_metrics_season on public.team_metrics (season);
+create index if not exists idx_team_metrics_pulled_at on public.team_metrics (pulled_at);
+
+alter table public.team_boxscores enable row level security;
+alter table public.team_metrics enable row level security;
+
+drop policy if exists team_boxscores_read on public.team_boxscores;
+create policy team_boxscores_read on public.team_boxscores
+for select to authenticated
+using (true);
+
+drop policy if exists team_metrics_read on public.team_metrics;
+create policy team_metrics_read on public.team_metrics
+for select to authenticated
+using (true);

--- a/supabase/migrations/20260306001000_fix_team_boxscores_metrics_pulled_at.sql
+++ b/supabase/migrations/20260306001000_fix_team_boxscores_metrics_pulled_at.sql
@@ -1,0 +1,8 @@
+alter table public.team_boxscores
+  add column if not exists pulled_at timestamptz not null default now();
+
+alter table public.team_metrics
+  add column if not exists pulled_at timestamptz not null default now();
+
+create index if not exists idx_team_boxscores_pulled_at on public.team_boxscores (pulled_at);
+create index if not exists idx_team_metrics_pulled_at on public.team_metrics (pulled_at);

--- a/supabase/migrations/20260306002000_alter_team_metrics_to_match_model.sql
+++ b/supabase/migrations/20260306002000_alter_team_metrics_to_match_model.sql
@@ -1,0 +1,14 @@
+alter table public.team_metrics
+  add column if not exists season int;
+
+alter table public.team_metrics
+  add column if not exists metric_set text;
+
+alter table public.team_metrics
+  add column if not exists verification_status text not null default 'partial';
+
+alter table public.team_metrics
+  add column if not exists verification_notes text;
+
+create index if not exists idx_team_metrics_unique_fallback
+  on public.team_metrics (season, team_id, metric_set);

--- a/supabase/migrations/20260306003000_alter_teams_to_match_model.sql
+++ b/supabase/migrations/20260306003000_alter_teams_to_match_model.sql
@@ -1,0 +1,23 @@
+alter table public.teams
+  add column if not exists season int;
+
+alter table public.teams
+  add column if not exists source_team_id text;
+
+alter table public.teams
+  add column if not exists team_name text;
+
+alter table public.teams
+  add column if not exists conference text;
+
+alter table public.teams
+  add column if not exists created_at timestamptz not null default now();
+
+alter table public.teams
+  add column if not exists updated_at timestamptz not null default now();
+
+create unique index if not exists idx_teams_unique_source
+  on public.teams (season, source_team_id);
+
+create unique index if not exists idx_teams_unique_name
+  on public.teams (season, team_name);


### PR DESCRIPTION
### Motivation
- Fix the normalization crash where `normalize_raw_to_public.py` failed with `psycopg.errors.UndefinedColumn: column "season" of relation "teams" does not exist` by making `public.teams` conform to the expected model schema so idempotent upserts succeed.

### Description
- Add a safe, additive SQL migration `supabase/migrations/20260306003000_alter_teams_to_match_model.sql` that adds `season`, `source_team_id`, `team_name`, `conference`, `created_at`, and `updated_at` (all with `IF NOT EXISTS`) and creates unique indexes on `(season, source_team_id)` and `(season, team_name)` to match the recommended model.

### Testing
- No automated tests were executed for this change because it is an SQL-only migration; please apply the migration and re-run `python scripts/normalize_raw_to_public.py` to verify the normalization step succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698975403668832b8547b60584aa958e)