### PR TITLE
Harden ML pipeline: always emit required model artifacts, add constant-prediction diagnostics, and fix variant training

### DIFF
--- a/.github/workflows/run-ml-pipeline.yml
+++ b/.github/workflows/run-ml-pipeline.yml
@@ -75,8 +75,37 @@ jobs:
       - name: Train models
         run: python ml/train_ml_models.py
 
+      - name: Inspect model artifacts
+        run: |
+          echo "Contents of ml/models:"
+          ls -lh ml/models || true
+          for f in ml/models/margin_model.json ml/models/total_model.json; do
+            if [ -f "$f" ]; then
+              echo "--- $f (first 30 lines) ---"
+              sed -n '1,30p' "$f"
+            else
+              echo "[ERROR] Missing $f"
+              exit 1
+            fi
+          done
+
       - name: Generate predictions
         run: python ml/predict_ml.py
+
+      - name: Validate prediction variance
+        run: |
+          python - <<'PY2'
+          import pandas as pd
+          p = "ml/predictions_latest.csv"
+          df = pd.read_csv(p)
+          m_std = float(pd.to_numeric(df["pred_margin_home"], errors="coerce").std(ddof=0))
+          t_std = float(pd.to_numeric(df["pred_total"], errors="coerce").std(ddof=0))
+          m_u = int(pd.to_numeric(df["pred_margin_home"], errors="coerce").nunique(dropna=True))
+          t_u = int(pd.to_numeric(df["pred_total"], errors="coerce").nunique(dropna=True))
+          print(f"[DIAG] rows={len(df)} margin_std={m_std:.6f} total_std={t_std:.6f} margin_unique={m_u} total_unique={t_u}")
+          if len(df) == 0 or m_std == 0.0 or t_std == 0.0 or m_u <= 1 or t_u <= 1:
+              raise SystemExit("Constant/invalid predictions in ml/predictions_latest.csv. Check model files, fallback mode, and feature variability.")
+          PY2
 
       - name: Backtest full season (manual only)
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/load_csv_to_db.py
+++ b/load_csv_to_db.py
@@ -40,6 +40,7 @@ AUTO_ADD_COLUMN_ALLOWLIST = {
     ("raw", "espn_team_game_logs"),
     ("raw", "espn_team_game_features"),
     ("raw", "espn_matchups_model_ready"),
+    ("raw", "model_features"),
 }
 
 # Optional: pack wide feature CSVs into a single JSON column to avoid Postgres row-size limits.

--- a/ml/predict_ml.py
+++ b/ml/predict_ml.py
@@ -64,8 +64,10 @@ def _require_model_fields(model: Dict[str, object], model_path: Path) -> None:
     if missing:
         raise ValueError(f"Model {model_path} missing required fields: {missing}")
 
-    if not isinstance(model["feature_order"], list) or not model["feature_order"]:
-        raise ValueError(f"Model {model_path} has empty/invalid feature_order")
+    if not isinstance(model["feature_order"], list):
+        raise ValueError(f"Model {model_path} has invalid feature_order")
+    if not model["feature_order"] and model.get("fallback") != "intercept_only":
+        raise ValueError(f"Model {model_path} has empty feature_order without intercept-only fallback flag")
 
     if not isinstance(model["coefficients"], list):
         raise ValueError(f"Model {model_path} has invalid coefficients (expected list)")
@@ -192,6 +194,30 @@ def _sort_for_determinism(out: pd.DataFrame) -> pd.DataFrame:
     return df.sort_values(["event_id"], kind="mergesort").reset_index(drop=True)
 
 
+def _emit_prediction_diagnostics(out: pd.DataFrame) -> None:
+    n_rows = int(len(out))
+    margin = pd.to_numeric(out["pred_margin_home"], errors="coerce")
+    total = pd.to_numeric(out["pred_total"], errors="coerce")
+
+    margin_std = float(margin.std(ddof=0)) if n_rows else 0.0
+    total_std = float(total.std(ddof=0)) if n_rows else 0.0
+    margin_unique = int(margin.nunique(dropna=True))
+    total_unique = int(total.nunique(dropna=True))
+
+    print("[DIAG] Prediction diagnostics")
+    print(f"[DIAG] rows={n_rows}")
+    print(f"[DIAG] pred_margin_home std={margin_std:.6f} unique={margin_unique}")
+    print(f"[DIAG] pred_total std={total_std:.6f} unique={total_unique}")
+    print(f"[DIAG] pred_margin_home top5={margin.value_counts(dropna=False).head(5).to_dict()}")
+    print(f"[DIAG] pred_total top5={total.value_counts(dropna=False).head(5).to_dict()}")
+
+    if n_rows == 0 or margin_std == 0.0 or total_std == 0.0 or margin_unique <= 1 or total_unique <= 1:
+        raise RuntimeError(
+            "Constant/invalid predictions detected. Inspect model artifacts (missing or fallback intercept-only), "
+            "feature matrix variability, and all-zero/NaN features before prediction."
+        )
+
+
 def predict(cfg: PredictConfig) -> pd.DataFrame:
     margin_model = _load_model(cfg.margin_model_path)
     total_model = _load_model(cfg.total_model_path)
@@ -243,6 +269,7 @@ def predict(cfg: PredictConfig) -> pd.DataFrame:
 
     cfg.out_path.parent.mkdir(parents=True, exist_ok=True)
     out.to_csv(cfg.out_path, index=False)
+    _emit_prediction_diagnostics(out)
     return out
 
 

--- a/ml/train_ml_models.py
+++ b/ml/train_ml_models.py
@@ -234,6 +234,54 @@ def _fit_model(
     return full_coef, rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean
 
 
+def _build_intercept_only_model(
+    *,
+    y: np.ndarray,
+    feature_cols: List[str],
+    reason: str,
+    rows_train: int,
+    rows_total: int,
+    rows_val: int,
+    cfg: TrainConfig,
+    target: str,
+    train_start_utc,
+    train_end_utc,
+    schema_hash: Optional[str],
+) -> Dict[str, object]:
+    y_num = pd.to_numeric(pd.Series(y), errors="coerce").to_numpy(dtype=np.float64)
+    y_clean = y_num[np.isfinite(y_num)]
+    intercept = float(np.mean(y_clean)) if y_clean.size else 0.0
+    rmse = float(np.sqrt(np.mean((y_clean - intercept) ** 2))) if y_clean.size else float("nan")
+    return {
+        "target": target,
+        "model_version": cfg.model_version,
+        "trained_at_utc": _utc_now_iso(),
+        "feature_schema_hash": schema_hash,
+        "train_start_utc": (train_start_utc.isoformat() if pd.notna(train_start_utc) else None),
+        "train_end_utc": (train_end_utc.isoformat() if pd.notna(train_end_utc) else None),
+        "intercept": intercept,
+        "coefficients": [0.0 for _ in feature_cols],
+        "feature_order": feature_cols,
+        "rmse": rmse,
+        "val_rmse": None,
+        "rows_total": rows_total,
+        "rows_train": rows_train,
+        "rows_train_clean": int(y_clean.size),
+        "rows_val": rows_val,
+        "ridge_lambda": float(cfg.ridge_lambda),
+        "val_split": float(max(0.0, min(0.5, float(cfg.val_split)))),
+        "min_train_rows": int(cfg.min_train_rows),
+        "n_features_total": int(len(feature_cols)),
+        "n_features_used": 0,
+        "dropped_const_features": feature_cols,
+        "feature_medians": {c: 0.0 for c in feature_cols},
+        "split_type": "time_series",
+        "sort_key": "game_datetime_utc",
+        "fallback": "intercept_only",
+        "fallback_reason": reason,
+    }
+
+
 def _rmse_from_coef(
     X: np.ndarray,
     y: np.ndarray,
@@ -329,11 +377,11 @@ def train_models(cfg: TrainConfig) -> Dict[str, Dict[str, object]]:
     df = _coerce_and_sort_by_datetime(df)
 
     feature_cols = _select_feature_cols(df)
-    if not feature_cols:
-        raise ValueError("No feature columns available for training.")
-
-    # ✅ NEW: Validate data before training
-    _validate_training_data(df, feature_cols, cfg)
+    if feature_cols:
+        # ✅ NEW: Validate data before training
+        _validate_training_data(df, feature_cols, cfg)
+    else:
+        print("[WARN] No feature columns available. Will emit intercept-only fallback models.", file=sys.stderr)
 
     val_ratio = max(0.0, min(0.5, float(cfg.val_split)))
     split_cfg = SplitConfig(val_ratio=val_ratio, test_ratio=0.0)
@@ -385,14 +433,53 @@ def train_models(cfg: TrainConfig) -> Dict[str, Dict[str, object]]:
         print(f"       Target std: {y_std:.2f}")
         
         if y_std < cfg.min_feature_variance:
-            raise ValueError(f"Target {target} has no variance in training set (std={y_std:.4f})")
+            print(f"[WARN] Target {target} has low variance (std={y_std:.4f}); fallback model will be written.")
+            model = _build_intercept_only_model(
+                y=y_train,
+                feature_cols=feature_cols,
+                reason=f"low_target_variance:{y_std:.6f}",
+                rows_train=rows_train,
+                rows_total=rows_total,
+                rows_val=rows_val,
+                cfg=cfg,
+                target=target,
+                train_start_utc=train_start_utc,
+                train_end_utc=train_end_utc,
+                schema_hash=schema_hash,
+            )
+            results[target] = model
+            cfg.out_dir.mkdir(parents=True, exist_ok=True)
+            (cfg.out_dir / fname).write_text(json.dumps(model, indent=2) + "\n")
+            print(f"[INFO] ✅ Fallback model saved to {cfg.out_dir / fname}")
+            continue
 
-        coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
-            X_train,
-            y_train,
-            ridge_lambda=cfg.ridge_lambda,
-            min_train_rows=cfg.min_train_rows,
-        )
+        try:
+            coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
+                X_train,
+                y_train,
+                ridge_lambda=cfg.ridge_lambda,
+                min_train_rows=cfg.min_train_rows,
+            )
+        except ValueError as e:
+            print(f"[WARN] {target}: {e}; writing intercept-only fallback model.")
+            model = _build_intercept_only_model(
+                y=y_train,
+                feature_cols=feature_cols,
+                reason=str(e),
+                rows_train=rows_train,
+                rows_total=rows_total,
+                rows_val=rows_val,
+                cfg=cfg,
+                target=target,
+                train_start_utc=train_start_utc,
+                train_end_utc=train_end_utc,
+                schema_hash=schema_hash,
+            )
+            results[target] = model
+            cfg.out_dir.mkdir(parents=True, exist_ok=True)
+            (cfg.out_dir / fname).write_text(json.dumps(model, indent=2) + "\n")
+            print(f"[INFO] ✅ Fallback model saved to {cfg.out_dir / fname}")
+            continue
         
         print(f"[INFO] Model trained:")
         print(f"       RMSE: {train_rmse:.2f}")
@@ -454,6 +541,8 @@ def train_models(cfg: TrainConfig) -> Dict[str, Dict[str, object]]:
         
         print(f"[INFO] ✅ Model saved to {cfg.out_dir / fname}")
         print("[INFO] ================================================\n")
+
+    print(f"[INFO] Model artifacts ready: {cfg.out_dir / 'margin_model.json'} ; {cfg.out_dir / 'total_model.json'}")
 
     return results
 

--- a/ml/train_variants.py
+++ b/ml/train_variants.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
 from typing import Dict, List
+import os
 
 import numpy as np
 import pandas as pd
@@ -35,6 +36,7 @@ from predict_ml import _load_features as _load_pred_features, _score_df, _requir
 WINDOWS = [4, 5, 6, 7, 10, 12]
 SUMMARY_PATH = Path("ml/variant_results.csv")
 MODELS_DIR = Path("ml/models")
+FEATURES_PATH = Path(os.getenv("ML_FEATURES_PATH", "ml/model_features.csv"))
 
 
 @dataclass
@@ -59,7 +61,7 @@ ID_COLS = {"event_id", "game_datetime_utc", "team_id_home", "team_id_away"}
 TARGET_COLS = {"actual_margin_home", "actual_total"}
 
 
-def _pick_features_for_window(df: pd.DataFrame, window: int) -> pd.DataFrame:
+def _pick_features_for_window(df: pd.DataFrame, window: int) -> tuple[pd.DataFrame, List[str]]:
     """
     Keep only:
       - recency features matching *_l{window}_pre
@@ -68,14 +70,15 @@ def _pick_features_for_window(df: pd.DataFrame, window: int) -> pd.DataFrame:
       - id cols (used for joins/sorting only, excluded from X)
     """
     out = df.copy()
+    window_cols = [c for c in out.columns if f"_l{window}_pre" in c]
     cols = [
         c for c in out.columns
-        if (f"_l{window}_pre" in c)
+        if (c in window_cols)
         or ("_season_pre" in c)
         or (c in TARGET_COLS)
         or (c in ID_COLS)
     ]
-    return out[cols]
+    return out[cols], window_cols
 
 
 def _feature_cols_only(df: pd.DataFrame) -> List[str]:
@@ -114,7 +117,8 @@ def _model_filename(variant: str, target_short: str) -> str:
 # ------------------------
 
 def train_and_eval_variants() -> List[VariantResult]:
-    df_raw = pd.read_csv("ml/model_features.csv")
+    print(f"[INFO] Loading features from {FEATURES_PATH}")
+    df_raw = pd.read_csv(FEATURES_PATH)
     df_raw = _coerce_and_sort_by_datetime(df_raw)
 
     results: List[VariantResult] = []
@@ -124,12 +128,16 @@ def train_and_eval_variants() -> List[VariantResult]:
         var_name = f"l{w}_simple"
         print(f"[INFO] Training variant {var_name}")
 
-        df_feat = _pick_features_for_window(df_raw, w)
+        df_feat, window_cols = _pick_features_for_window(df_raw, w)
         df_feat = df_feat.sort_values("game_datetime_utc", kind="mergesort")
+
+        if not window_cols:
+            print(f"[WARN] No window-specific columns found for window {w}. Skipping variant {var_name}.")
+            continue
 
         feat_cols = _feature_cols_only(df_feat)
         if not feat_cols:
-            print(f"[WARN] No feature columns found for window {w}. Skipping.")
+            print(f"[WARN] No feature columns found for window {w}. Skipping variant {var_name}.")
             continue
 
         # Train margin + total
@@ -144,12 +152,16 @@ def train_and_eval_variants() -> List[VariantResult]:
 
             X = Xdf.to_numpy(dtype=np.float64)
 
-            coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
-                X,
-                y,
-                ridge_lambda=1e-3,
-                min_train_rows=25,
-            )
+            try:
+                coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
+                    X,
+                    y,
+                    ridge_lambda=1e-3,
+                    min_train_rows=25,
+                )
+            except ValueError as e:
+                print(f"[WARN] Skipping {var_name}/{short}: {e}")
+                continue
 
             # Save JSON model
             model_data = {
@@ -182,7 +194,7 @@ def train_and_eval_variants() -> List[VariantResult]:
 
     # Ensemble evaluation
     print("[INFO] Evaluating ensembles...")
-    pred_df = _load_pred_features(Path("ml/model_features.csv"))
+    pred_df = _load_pred_features(FEATURES_PATH)
 
     # Score all single models
     score_cache: Dict[str, np.ndarray] = {}


### PR DESCRIPTION
### Motivation
- Prevent silent pipeline failure where missing/empty models produce constant predictions and CI passes; ensure model artifacts always exist and surface root causes quickly.
- Make variant training robust to missing window-specific columns and sparse training data so CI doesn't crash on ImportError / low-data conditions.
- Avoid DB load blocking the pipeline due to schema drift in wide, evolving feature CSVs.

### Description
- `ml/train_ml_models.py`: always writes `ml/models/margin_model.json` and `ml/models/total_model.json`; added `_build_intercept_only_model(...)` to produce explicit intercept-only fallback models when training cannot proceed, and print a final line showing artifact paths; training now catches low-variance or insufficient-data conditions and writes flagged fallback JSON (`"fallback": "intercept_only"`, `"fallback_reason"`).
- `ml/predict_ml.py`: added prediction diagnostics that print row count, stddev for `pred_margin_home` and `pred_total`, unique counts and top-5 value counts, and fail the run with a helpful error when predictions are constant/invalid.
- `ml/train_variants.py`: fixed imports to use `_fit_model`, added `ML_FEATURES_PATH` override, skip variants if window-specific columns (e.g. `_l4_pre`) are not present, and catch per-variant `ValueError` (insufficient clean rows) so training continues and `ml/variant_results.csv` is still produced.
- `load_csv_to_db.py`: added `("raw", "model_features")` to `AUTO_ADD_COLUMN_ALLOWLIST` so new feature columns in `ml/model_features.csv` can be auto-added as text instead of blocking the run.
- `.github/workflows/run-ml-pipeline.yml`: added an **Inspect model artifacts** step immediately after training to list `ml/models/` and print the first ~30 lines of both required model JSONs, and added a **Validate prediction variance** step after predictions that fails CI on constant predictions; `train_ml_variants.yml` already uses `actions/upload-artifact@v4` so no change required there.
- Model validation change: model JSONs with empty `feature_order` are allowed only when `fallback` is set to `intercept_only`.

### Testing
- Ran syntax check: `python -m py_compile ml/train_ml_models.py ml/predict_ml.py ml/train_variants.py load_csv_to_db.py` and it succeeded with no syntax errors.
- Trained with a minimal fixture `ml/model_features.csv` (3 rows) using `python ml/train_ml_models.py`, and the run produced `ml/models/margin_model.json` and `ml/models/total_model.json` as intercept-only fallback models and printed a final artifact-ready line (success).
- Ran `python ml/predict_ml.py` against the fallback models: diagnostics were printed (rows, stddev, unique counts, top-5 value counts) and the script raised a clear RuntimeError for constant predictions as intended to surface issues early (expected failure for intercept-only fixture).
- Ran `python ml/train_variants.py` against a small fixture: it skipped variants that lacked `_l{window}_pre` columns, printed warnings for skipped windows, and successfully wrote `ml/variant_results.csv` (success).

If CI shows constant predictions, inspect model JSONs for `"fallback": "intercept_only"` and `fallback_reason`, and inspect the printed `[DIAG]` output from the prediction step to determine whether the issue is missing models, all-zero/NaN features, or insufficient training data.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f797e2d00832b8ea1005e4b8da05d)