### PR TITLE
Refactor ML pipeline to derive rolling features from slim raw core table

### DIFF
--- a/.github/workflows/run-ml-pipeline.yml
+++ b/.github/workflows/run-ml-pipeline.yml
@@ -32,16 +32,18 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
           DB_SCHEMA: "raw"
-          ESPN_FEATURES_TABLE: "espn_team_game_features"
+          ESPN_FEATURES_TABLE: "espn_team_game_core"
         run: |
+          python scripts/build_espn_team_game_core.py
           python ml/pipeline.py
 
       - name: Generate feature matrix files (DB-backed)
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
           DB_SCHEMA: "raw"
-          ESPN_FEATURES_TABLE: "espn_team_game_features"
+          ESPN_FEATURES_TABLE: "espn_team_game_core"
         run: |
+          python scripts/build_espn_team_game_core.py
           python ml/feature_matrix.py
 
       - name: Print ML CSV headers
@@ -62,6 +64,7 @@ jobs:
           ls -lh ml/*.csv ml/*.json ml/*.txt ml/models/*.json || true
 
       - name: Load ML CSV artifacts to Supabase DB (raw schema)
+        id: load_ml_csv
         continue-on-error: true
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
@@ -70,13 +73,54 @@ jobs:
           LOAD_MODE: "replace"
           SKIP_MISSING: "1"
         run: |
-          python load_csv_to_db.py
+          set -o pipefail
+          python load_csv_to_db.py 2>&1 | tee /tmp/load_ml_csv.log
+
+      - name: Report DB load result + schema guidance
+        if: ${{ always() }}
+        run: |
+          echo "DB load step outcome: ${{ steps.load_ml_csv.outcome }}"
+          if [ "${{ steps.load_ml_csv.outcome }}" != "success" ]; then
+            echo "DB load failed. Suggested SQL (if present in logs):"
+            awk '/\[SCHEMA_DRIFT_SQL_BEGIN\]/{flag=1;next}/\[SCHEMA_DRIFT_SQL_END\]/{flag=0}flag' /tmp/load_ml_csv.log || true
+          else
+            echo "DB load succeeded."
+          fi
 
       - name: Train models
         run: python ml/train_ml_models.py
 
+      - name: Inspect model artifacts
+        run: |
+          echo "Contents of ml/models:"
+          ls -lh ml/models || true
+          for f in ml/models/margin_model.json ml/models/total_model.json; do
+            if [ -f "$f" ]; then
+              echo "--- $f (first 30 lines) ---"
+              sed -n '1,30p' "$f"
+            else
+              echo "[ERROR] Missing $f"
+              exit 1
+            fi
+          done
+
       - name: Generate predictions
         run: python ml/predict_ml.py
+
+      - name: Validate prediction variance
+        run: |
+          python - <<'PY2'
+          import pandas as pd
+          p = "ml/predictions_latest.csv"
+          df = pd.read_csv(p)
+          m_std = float(pd.to_numeric(df["pred_margin_home"], errors="coerce").std(ddof=0))
+          t_std = float(pd.to_numeric(df["pred_total"], errors="coerce").std(ddof=0))
+          m_u = int(pd.to_numeric(df["pred_margin_home"], errors="coerce").nunique(dropna=True))
+          t_u = int(pd.to_numeric(df["pred_total"], errors="coerce").nunique(dropna=True))
+          print(f"[DIAG] rows={len(df)} margin_std={m_std:.6f} total_std={t_std:.6f} margin_unique={m_u} total_unique={t_u}")
+          if len(df) == 0 or m_std == 0.0 or t_std == 0.0 or m_u <= 1 or t_u <= 1:
+              raise SystemExit("Constant/invalid predictions in ml/predictions_latest.csv. Check model files, fallback mode, and feature variability.")
+          PY2
 
       - name: Backtest full season (manual only)
         if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/load_csv_to_db.py
+++ b/load_csv_to_db.py
@@ -42,6 +42,8 @@ AUTO_ADD_COLUMN_ALLOWLIST = {
     ("raw", "espn_matchups_model_ready"),
 }
 
+ALLOW_SCHEMA_MIGRATION = (os.getenv("ALLOW_SCHEMA_MIGRATION") or "0").strip().lower() in ("1", "true", "yes")
+
 # Optional: pack wide feature CSVs into a single JSON column to avoid Postgres row-size limits.
 PACK_FEATURES_JSON = (os.getenv("PACK_FEATURES_JSON") or "1").strip().lower() in ("1", "true", "yes")
 
@@ -424,6 +426,131 @@ def _ensure_columns_exist(conn: psycopg.Connection, schema: str, table: str, req
 
 def _get_table_spec(table_name: str) -> dict:
     return TABLE_SPECS.get(table_name, {"required_cols": [], "row_hash_keys": [], "not_null": [], "dtypes": {}})
+
+
+def _is_blank(value: object) -> bool:
+    return _normalize_str(value) == ""
+
+
+def _infer_types_from_csv(local_path: Path, columns: List[str], sample_limit: int = 5000) -> Dict[str, Dict[str, str]]:
+    stats = {c: {"seen": 0, "non_numeric": 0, "has_fractional": 0, "example": ""} for c in columns}
+
+    with local_path.open("r", encoding="utf-8", errors="replace", newline="") as f:
+        reader = csv.DictReader(f)
+        for i, row in enumerate(reader):
+            if i >= sample_limit:
+                break
+            for c in columns:
+                raw = row.get(c, "")
+                if _is_blank(raw):
+                    continue
+
+                stats[c]["seen"] += 1
+                text = _normalize_str(raw)
+                try:
+                    num = Decimal(text)
+                except InvalidOperation:
+                    stats[c]["non_numeric"] += 1
+                    if not stats[c]["example"]:
+                        stats[c]["example"] = text
+                    continue
+
+                if num != num.to_integral_value():
+                    stats[c]["has_fractional"] += 1
+
+    inferred: Dict[str, Dict[str, str]] = {}
+    for c, s in stats.items():
+        if s["seen"] == 0:
+            inferred[c] = {
+                "type": "type ambiguous",
+                "reason": "no non-empty sample values in CSV",
+            }
+            continue
+        if s["non_numeric"] > 0:
+            sample = f" sample_non_numeric='{s['example']}'" if s["example"] else ""
+            inferred[c] = {
+                "type": "type ambiguous",
+                "reason": f"{s['non_numeric']} non-numeric value(s) in sample;{sample}".strip(),
+            }
+            continue
+
+        inferred[c] = {
+            "type": "double precision",
+            "reason": f"{s['seen']} numeric sample value(s), fractional_values={s['has_fractional']}",
+        }
+
+    return inferred
+
+
+def _build_schema_drift_sql(schema: str, table: str, inferred: Dict[str, Dict[str, str]]) -> Tuple[str, List[str]]:
+    sql_lines: List[str] = []
+    ambiguous: List[str] = []
+    for col, meta in inferred.items():
+        inferred_type = meta["type"]
+        if inferred_type == "double precision":
+            sql_lines.append(
+                f"alter table {_qualified_table(schema, table)} add column if not exists {_quote_ident(col)} {inferred_type};"
+            )
+        else:
+            ambiguous.append(col)
+            sql_lines.append(f"-- type ambiguous for {col}: {meta['reason']}")
+
+    banner = (
+        "-- Schema drift fix for CSV -> Postgres load\n"
+        f"-- destination: {schema}.{table}\n"
+        "-- Add only missing columns. Nullable by default.\n"
+    )
+    return banner + "\n".join(sql_lines), ambiguous
+
+
+def _ensure_columns_with_schema_guidance(
+    conn: psycopg.Connection,
+    schema: str,
+    table: str,
+    csv_cols: List[str],
+    local_path: Path,
+) -> None:
+    try:
+        _ensure_columns_exist(conn, schema, table, csv_cols)
+        return
+    except ValueError as exc:
+        msg = str(exc)
+        if "Auto-add is disabled for this table" not in msg:
+            raise
+
+    table_cols = _get_table_columns(conn, schema, table)
+    missing_cols = [c for c in csv_cols if c not in table_cols]
+    inferred = _infer_types_from_csv(local_path, missing_cols)
+    sql_block, ambiguous_cols = _build_schema_drift_sql(schema, table, inferred)
+
+    print(f"[SCHEMA_DRIFT] destination={schema}.{table}")
+    print(f"[SCHEMA_DRIFT] missing_columns={missing_cols}")
+    print("[SCHEMA_DRIFT_SQL_BEGIN]")
+    print(sql_block)
+    print("[SCHEMA_DRIFT_SQL_END]")
+
+    if not ALLOW_SCHEMA_MIGRATION:
+        raise RuntimeError(
+            f"{schema}.{table}: CSV has missing columns and auto-add is disabled. "
+            "Set ALLOW_SCHEMA_MIGRATION=1 to auto-apply inferred ALTER TABLE statements "
+            "(only when all missing columns infer cleanly as numeric)."
+        )
+
+    if ambiguous_cols:
+        raise RuntimeError(
+            f"{schema}.{table}: ALLOW_SCHEMA_MIGRATION=1 but type inference is ambiguous for columns: {ambiguous_cols}. "
+            "Not auto-running ALTER TABLE; apply SQL manually."
+        )
+
+    with conn.cursor() as cur:
+        for col, meta in inferred.items():
+            cur.execute(
+                f"alter table {_qualified_table(schema, table)} "
+                f"add column if not exists {_quote_ident(col)} {meta['type']};"
+            )
+
+    conn.commit()
+    print(f"[INFO] Auto-applied schema migration for {schema}.{table} because ALLOW_SCHEMA_MIGRATION=1")
 
 
 def _required_defaults_for_table(table_name: str) -> dict:
@@ -1012,7 +1139,7 @@ def _upsert_from_staging(conn: psycopg.Connection, schema: str, table: str, loca
     csv_cols = _read_csv_header_columns(local_path)
     _validate_csv_header(csv_cols, local_path)
 
-    _ensure_columns_exist(conn, schema, table, csv_cols)
+    _ensure_columns_with_schema_guidance(conn, schema, table, csv_cols, local_path)
 
     table_cols = _get_table_columns(conn, schema, table)
     missing_in_table = [c for c in csv_cols if c not in table_cols]
@@ -1138,7 +1265,7 @@ def load_one(local_path: str, table_name: str) -> None:
                 if LOAD_MODE == "replace":
                     csv_cols = _read_csv_header_columns(prepared)
                     _validate_csv_header(csv_cols, prepared)
-                    _ensure_columns_exist(conn, DB_SCHEMA, table_name, csv_cols)
+                    _ensure_columns_with_schema_guidance(conn, DB_SCHEMA, table_name, csv_cols, prepared)
 
                     pk_cols = _get_primary_key_columns(conn, DB_SCHEMA, table_name)
 
@@ -1166,7 +1293,7 @@ def load_one(local_path: str, table_name: str) -> None:
                 elif LOAD_MODE == "append":
                     csv_cols = _read_csv_header_columns(prepared)
                     _validate_csv_header(csv_cols, prepared)
-                    _ensure_columns_exist(conn, DB_SCHEMA, table_name, csv_cols)
+                    _ensure_columns_with_schema_guidance(conn, DB_SCHEMA, table_name, csv_cols, prepared)
                     _copy_csv_into_table(conn, qt, prepared)
 
                 elif LOAD_MODE == "upsert":

--- a/ml/feature_matrix.py
+++ b/ml/feature_matrix.py
@@ -3,7 +3,7 @@
 Feature matrix builder for CBB models.
 
 Inputs (preferred order):
-  1) Supabase Postgres table: raw.espn_team_game_features (when SUPABASE_DB_URL is set)
+  1) Supabase Postgres table: raw.espn_team_game_core (when SUPABASE_DB_URL is set)
   2) Local CSV: espn_team_game_features.csv
 
 Targets (scores) source:
@@ -56,7 +56,7 @@ except Exception:
 
 SUPABASE_DB_URL = (os.getenv("SUPABASE_DB_URL") or "").strip()
 DB_SCHEMA = (os.getenv("DB_SCHEMA") or "raw").strip()
-DB_TABLE = (os.getenv("ESPN_FEATURES_TABLE") or "espn_team_game_features").strip()
+DB_TABLE = (os.getenv("ESPN_FEATURES_TABLE") or "espn_team_game_core").strip()
 DB_LIMIT = (os.getenv("ESPN_FEATURES_LIMIT") or "").strip()
 
 # Scores table (targets)
@@ -191,6 +191,7 @@ def _load_features_from_db(schema: str, table: str, limit_str: str) -> pd.DataFr
         df = pd.read_sql(sql, conn)
 
     df = _expand_features_json(df)
+    df = _derive_features_if_needed(df)
     print(f"[INFO] Loaded features from DB: {schema}.{table} rows={len(df)} cols={len(df.columns)}")
     return df
 
@@ -200,8 +201,89 @@ def _load_features_from_csv(path: Path) -> pd.DataFrame:
         raise FileNotFoundError(f"Missing feature store: {path}")
     df = pd.read_csv(path)
     df = _expand_features_json(df)
+    df = _derive_features_if_needed(df)
     print(f"[INFO] Loaded features from CSV: rows={len(df)} cols={len(df.columns)}")
     return df
+
+
+def _safe_div(numer: pd.Series, denom: pd.Series) -> pd.Series:
+    n = pd.to_numeric(numer, errors="coerce")
+    d = pd.to_numeric(denom, errors="coerce")
+    out = n / d.replace(0, np.nan)
+    return out.replace([np.inf, -np.inf], np.nan)
+
+
+def _rolling_pre(df: pd.DataFrame, metric: str) -> pd.DataFrame:
+    out = df.copy()
+    s = pd.to_numeric(out[metric], errors="coerce")
+    for w in LOOKBACK_WINDOWS:
+        col = f"{metric}_{w}_pre"
+        out[col] = (
+            s.groupby(out["team_id"], dropna=False)
+            .transform(lambda g: g.shift(1).rolling(window=int(w[1:]), min_periods=1).mean())
+        )
+    return out
+
+
+def _games_last_days(df: pd.DataFrame, days: int) -> pd.Series:
+    out = pd.Series(np.nan, index=df.index, dtype=float)
+    for _, idx in df.groupby("team_id", dropna=False).groups.items():
+        sub = df.loc[idx].sort_values("game_dt")
+        ts = sub["game_dt"].astype("int64") // 10**9
+        vals = []
+        for i, t in enumerate(ts):
+            low = t - days * 86400
+            c = int(((ts[:i] >= low) & (ts[:i] < t)).sum())
+            vals.append(float(c))
+        out.loc[sub.index] = vals
+    return out
+
+
+def _derive_features_if_needed(df: pd.DataFrame) -> pd.DataFrame:
+    pre_cols = [c for c in df.columns if c.endswith("_l7_pre")]
+    if pre_cols:
+        return df
+
+    required = {"event_id", "team_id", "team", "home_away", "game_datetime_utc"}
+    if not required.issubset(df.columns):
+        return df
+
+    # If no precomputed pre-game features exist, derive from boxscore primitives.
+    out = df.copy()
+    out["game_dt"] = pd.to_datetime(out["game_datetime_utc"], utc=True, errors="coerce")
+    out = out.sort_values(["team_id", "game_dt", "event_id"], na_position="last").reset_index(drop=True)
+
+    # base rates from raw boxscore primitives
+    out["poss"] = pd.to_numeric(out.get("fga"), errors="coerce") - pd.to_numeric(out.get("orb"), errors="coerce") + pd.to_numeric(out.get("tov"), errors="coerce") + 0.44 * pd.to_numeric(out.get("fta"), errors="coerce")
+    out["efg"] = _safe_div(pd.to_numeric(out.get("fgm"), errors="coerce") + 0.5 * pd.to_numeric(out.get("tpm"), errors="coerce"), out.get("fga"))
+    out["ftr"] = _safe_div(out.get("fta"), out.get("fga"))
+    out["3par"] = _safe_div(out.get("tpa"), out.get("fga"))
+    out["tov_pct"] = _safe_div(out.get("tov"), out.get("poss"))
+    out["pace"] = pd.to_numeric(out.get("poss"), errors="coerce")
+    out["ortg"] = 100.0 * _safe_div(out.get("points_for"), out.get("poss"))
+    out["drtg"] = 100.0 * _safe_div(out.get("points_against"), out.get("poss"))
+    out["netrtg"] = out["ortg"] - out["drtg"]
+
+    # opponent rebound context per game for orb_pct/drb_pct
+    opp = out[["event_id", "team_id", "orb", "drb"]].rename(columns={"team_id": "opp_team_id", "orb": "opp_orb", "drb": "opp_drb"})
+    out = out.merge(opp, on="event_id", how="left")
+    out = out[out["team_id"] != out["opp_team_id"]].copy()
+    out["orb_pct"] = _safe_div(out.get("orb"), pd.to_numeric(out.get("orb"), errors="coerce") + pd.to_numeric(out.get("opp_drb"), errors="coerce"))
+    out["drb_pct"] = _safe_div(out.get("drb"), pd.to_numeric(out.get("drb"), errors="coerce") + pd.to_numeric(out.get("opp_orb"), errors="coerce"))
+
+    metric_candidates = ["ortg", "drtg", "netrtg", "pace", "efg", "tov_pct", "orb_pct", "drb_pct", "ftr", "3par"]
+    for m in metric_candidates:
+        if m in out.columns:
+            out = _rolling_pre(out, m)
+
+    out["games_last_3_days"] = _games_last_days(out, 3)
+    out["games_last_5_days"] = _games_last_days(out, 5)
+    out["games_last_7_days"] = _games_last_days(out, 7)
+    out["games_last_10_days"] = _games_last_days(out, 10)
+    out["exp_margin"] = out.get("netrtg_l7_pre")
+
+    print("[INFO] Derived pre-game rolling features from raw boxscore primitives")
+    return out
 
 
 def _load_features(cfg: BuildConfig) -> pd.DataFrame:

--- a/ml/predict_ml.py
+++ b/ml/predict_ml.py
@@ -64,8 +64,10 @@ def _require_model_fields(model: Dict[str, object], model_path: Path) -> None:
     if missing:
         raise ValueError(f"Model {model_path} missing required fields: {missing}")
 
-    if not isinstance(model["feature_order"], list) or not model["feature_order"]:
-        raise ValueError(f"Model {model_path} has empty/invalid feature_order")
+    if not isinstance(model["feature_order"], list):
+        raise ValueError(f"Model {model_path} has invalid feature_order")
+    if not model["feature_order"] and model.get("fallback") != "intercept_only":
+        raise ValueError(f"Model {model_path} has empty feature_order without intercept-only fallback flag")
 
     if not isinstance(model["coefficients"], list):
         raise ValueError(f"Model {model_path} has invalid coefficients (expected list)")
@@ -192,6 +194,30 @@ def _sort_for_determinism(out: pd.DataFrame) -> pd.DataFrame:
     return df.sort_values(["event_id"], kind="mergesort").reset_index(drop=True)
 
 
+def _emit_prediction_diagnostics(out: pd.DataFrame) -> None:
+    n_rows = int(len(out))
+    margin = pd.to_numeric(out["pred_margin_home"], errors="coerce")
+    total = pd.to_numeric(out["pred_total"], errors="coerce")
+
+    margin_std = float(margin.std(ddof=0)) if n_rows else 0.0
+    total_std = float(total.std(ddof=0)) if n_rows else 0.0
+    margin_unique = int(margin.nunique(dropna=True))
+    total_unique = int(total.nunique(dropna=True))
+
+    print("[DIAG] Prediction diagnostics")
+    print(f"[DIAG] rows={n_rows}")
+    print(f"[DIAG] pred_margin_home std={margin_std:.6f} unique={margin_unique}")
+    print(f"[DIAG] pred_total std={total_std:.6f} unique={total_unique}")
+    print(f"[DIAG] pred_margin_home top5={margin.value_counts(dropna=False).head(5).to_dict()}")
+    print(f"[DIAG] pred_total top5={total.value_counts(dropna=False).head(5).to_dict()}")
+
+    if n_rows == 0 or margin_std == 0.0 or total_std == 0.0 or margin_unique <= 1 or total_unique <= 1:
+        raise RuntimeError(
+            "Constant/invalid predictions detected. Inspect model artifacts (missing or fallback intercept-only), "
+            "feature matrix variability, and all-zero/NaN features before prediction."
+        )
+
+
 def predict(cfg: PredictConfig) -> pd.DataFrame:
     margin_model = _load_model(cfg.margin_model_path)
     total_model = _load_model(cfg.total_model_path)
@@ -243,6 +269,7 @@ def predict(cfg: PredictConfig) -> pd.DataFrame:
 
     cfg.out_path.parent.mkdir(parents=True, exist_ok=True)
     out.to_csv(cfg.out_path, index=False)
+    _emit_prediction_diagnostics(out)
     return out
 
 

--- a/ml/train_ml_models.py
+++ b/ml/train_ml_models.py
@@ -234,6 +234,54 @@ def _fit_model(
     return full_coef, rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean
 
 
+def _build_intercept_only_model(
+    *,
+    y: np.ndarray,
+    feature_cols: List[str],
+    reason: str,
+    rows_train: int,
+    rows_total: int,
+    rows_val: int,
+    cfg: TrainConfig,
+    target: str,
+    train_start_utc,
+    train_end_utc,
+    schema_hash: Optional[str],
+) -> Dict[str, object]:
+    y_num = pd.to_numeric(pd.Series(y), errors="coerce").to_numpy(dtype=np.float64)
+    y_clean = y_num[np.isfinite(y_num)]
+    intercept = float(np.mean(y_clean)) if y_clean.size else 0.0
+    rmse = float(np.sqrt(np.mean((y_clean - intercept) ** 2))) if y_clean.size else float("nan")
+    return {
+        "target": target,
+        "model_version": cfg.model_version,
+        "trained_at_utc": _utc_now_iso(),
+        "feature_schema_hash": schema_hash,
+        "train_start_utc": (train_start_utc.isoformat() if pd.notna(train_start_utc) else None),
+        "train_end_utc": (train_end_utc.isoformat() if pd.notna(train_end_utc) else None),
+        "intercept": intercept,
+        "coefficients": [0.0 for _ in feature_cols],
+        "feature_order": feature_cols,
+        "rmse": rmse,
+        "val_rmse": None,
+        "rows_total": rows_total,
+        "rows_train": rows_train,
+        "rows_train_clean": int(y_clean.size),
+        "rows_val": rows_val,
+        "ridge_lambda": float(cfg.ridge_lambda),
+        "val_split": float(max(0.0, min(0.5, float(cfg.val_split)))),
+        "min_train_rows": int(cfg.min_train_rows),
+        "n_features_total": int(len(feature_cols)),
+        "n_features_used": 0,
+        "dropped_const_features": feature_cols,
+        "feature_medians": {c: 0.0 for c in feature_cols},
+        "split_type": "time_series",
+        "sort_key": "game_datetime_utc",
+        "fallback": "intercept_only",
+        "fallback_reason": reason,
+    }
+
+
 def _rmse_from_coef(
     X: np.ndarray,
     y: np.ndarray,
@@ -329,11 +377,11 @@ def train_models(cfg: TrainConfig) -> Dict[str, Dict[str, object]]:
     df = _coerce_and_sort_by_datetime(df)
 
     feature_cols = _select_feature_cols(df)
-    if not feature_cols:
-        raise ValueError("No feature columns available for training.")
-
-    # ✅ NEW: Validate data before training
-    _validate_training_data(df, feature_cols, cfg)
+    if feature_cols:
+        # ✅ NEW: Validate data before training
+        _validate_training_data(df, feature_cols, cfg)
+    else:
+        print("[WARN] No feature columns available. Will emit intercept-only fallback models.", file=sys.stderr)
 
     val_ratio = max(0.0, min(0.5, float(cfg.val_split)))
     split_cfg = SplitConfig(val_ratio=val_ratio, test_ratio=0.0)
@@ -385,14 +433,53 @@ def train_models(cfg: TrainConfig) -> Dict[str, Dict[str, object]]:
         print(f"       Target std: {y_std:.2f}")
         
         if y_std < cfg.min_feature_variance:
-            raise ValueError(f"Target {target} has no variance in training set (std={y_std:.4f})")
+            print(f"[WARN] Target {target} has low variance (std={y_std:.4f}); fallback model will be written.")
+            model = _build_intercept_only_model(
+                y=y_train,
+                feature_cols=feature_cols,
+                reason=f"low_target_variance:{y_std:.6f}",
+                rows_train=rows_train,
+                rows_total=rows_total,
+                rows_val=rows_val,
+                cfg=cfg,
+                target=target,
+                train_start_utc=train_start_utc,
+                train_end_utc=train_end_utc,
+                schema_hash=schema_hash,
+            )
+            results[target] = model
+            cfg.out_dir.mkdir(parents=True, exist_ok=True)
+            (cfg.out_dir / fname).write_text(json.dumps(model, indent=2) + "\n")
+            print(f"[INFO] ✅ Fallback model saved to {cfg.out_dir / fname}")
+            continue
 
-        coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
-            X_train,
-            y_train,
-            ridge_lambda=cfg.ridge_lambda,
-            min_train_rows=cfg.min_train_rows,
-        )
+        try:
+            coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
+                X_train,
+                y_train,
+                ridge_lambda=cfg.ridge_lambda,
+                min_train_rows=cfg.min_train_rows,
+            )
+        except ValueError as e:
+            print(f"[WARN] {target}: {e}; writing intercept-only fallback model.")
+            model = _build_intercept_only_model(
+                y=y_train,
+                feature_cols=feature_cols,
+                reason=str(e),
+                rows_train=rows_train,
+                rows_total=rows_total,
+                rows_val=rows_val,
+                cfg=cfg,
+                target=target,
+                train_start_utc=train_start_utc,
+                train_end_utc=train_end_utc,
+                schema_hash=schema_hash,
+            )
+            results[target] = model
+            cfg.out_dir.mkdir(parents=True, exist_ok=True)
+            (cfg.out_dir / fname).write_text(json.dumps(model, indent=2) + "\n")
+            print(f"[INFO] ✅ Fallback model saved to {cfg.out_dir / fname}")
+            continue
         
         print(f"[INFO] Model trained:")
         print(f"       RMSE: {train_rmse:.2f}")
@@ -454,6 +541,8 @@ def train_models(cfg: TrainConfig) -> Dict[str, Dict[str, object]]:
         
         print(f"[INFO] ✅ Model saved to {cfg.out_dir / fname}")
         print("[INFO] ================================================\n")
+
+    print(f"[INFO] Model artifacts ready: {cfg.out_dir / 'margin_model.json'} ; {cfg.out_dir / 'total_model.json'}")
 
     return results
 

--- a/ml/train_variants.py
+++ b/ml/train_variants.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
 from typing import Dict, List
+import os
 
 import numpy as np
 import pandas as pd
@@ -35,6 +36,7 @@ from predict_ml import _load_features as _load_pred_features, _score_df, _requir
 WINDOWS = [4, 5, 6, 7, 10, 12]
 SUMMARY_PATH = Path("ml/variant_results.csv")
 MODELS_DIR = Path("ml/models")
+FEATURES_PATH = Path(os.getenv("ML_FEATURES_PATH", "ml/model_features.csv"))
 
 
 @dataclass
@@ -59,7 +61,7 @@ ID_COLS = {"event_id", "game_datetime_utc", "team_id_home", "team_id_away"}
 TARGET_COLS = {"actual_margin_home", "actual_total"}
 
 
-def _pick_features_for_window(df: pd.DataFrame, window: int) -> pd.DataFrame:
+def _pick_features_for_window(df: pd.DataFrame, window: int) -> tuple[pd.DataFrame, List[str]]:
     """
     Keep only:
       - recency features matching *_l{window}_pre
@@ -68,14 +70,15 @@ def _pick_features_for_window(df: pd.DataFrame, window: int) -> pd.DataFrame:
       - id cols (used for joins/sorting only, excluded from X)
     """
     out = df.copy()
+    window_cols = [c for c in out.columns if f"_l{window}_pre" in c]
     cols = [
         c for c in out.columns
-        if (f"_l{window}_pre" in c)
+        if (c in window_cols)
         or ("_season_pre" in c)
         or (c in TARGET_COLS)
         or (c in ID_COLS)
     ]
-    return out[cols]
+    return out[cols], window_cols
 
 
 def _feature_cols_only(df: pd.DataFrame) -> List[str]:
@@ -114,7 +117,8 @@ def _model_filename(variant: str, target_short: str) -> str:
 # ------------------------
 
 def train_and_eval_variants() -> List[VariantResult]:
-    df_raw = pd.read_csv("ml/model_features.csv")
+    print(f"[INFO] Loading features from {FEATURES_PATH}")
+    df_raw = pd.read_csv(FEATURES_PATH)
     df_raw = _coerce_and_sort_by_datetime(df_raw)
 
     results: List[VariantResult] = []
@@ -124,12 +128,16 @@ def train_and_eval_variants() -> List[VariantResult]:
         var_name = f"l{w}_simple"
         print(f"[INFO] Training variant {var_name}")
 
-        df_feat = _pick_features_for_window(df_raw, w)
+        df_feat, window_cols = _pick_features_for_window(df_raw, w)
         df_feat = df_feat.sort_values("game_datetime_utc", kind="mergesort")
+
+        if not window_cols:
+            print(f"[WARN] No window-specific columns found for window {w}. Skipping variant {var_name}.")
+            continue
 
         feat_cols = _feature_cols_only(df_feat)
         if not feat_cols:
-            print(f"[WARN] No feature columns found for window {w}. Skipping.")
+            print(f"[WARN] No feature columns found for window {w}. Skipping variant {var_name}.")
             continue
 
         # Train margin + total
@@ -144,12 +152,16 @@ def train_and_eval_variants() -> List[VariantResult]:
 
             X = Xdf.to_numpy(dtype=np.float64)
 
-            coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
-                X,
-                y,
-                ridge_lambda=1e-3,
-                min_train_rows=25,
-            )
+            try:
+                coef, train_rmse, keep_mask, medians_full, dropped_const_idx, rows_train_clean = _fit_model(
+                    X,
+                    y,
+                    ridge_lambda=1e-3,
+                    min_train_rows=25,
+                )
+            except ValueError as e:
+                print(f"[WARN] Skipping {var_name}/{short}: {e}")
+                continue
 
             # Save JSON model
             model_data = {
@@ -182,7 +194,7 @@ def train_and_eval_variants() -> List[VariantResult]:
 
     # Ensemble evaluation
     print("[INFO] Evaluating ensembles...")
-    pred_df = _load_pred_features(Path("ml/model_features.csv"))
+    pred_df = _load_pred_features(FEATURES_PATH)
 
     # Score all single models
     score_cache: Dict[str, np.ndarray] = {}

--- a/scripts/build_espn_team_game_core.py
+++ b/scripts/build_espn_team_game_core.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Build a slim raw.espn_team_game_core table from raw.espn_team_game_logs.
+
+Purpose:
+- Keep only essential raw box score + score columns in DB.
+- Move rolling/derived feature generation to Python (ml/feature_matrix.py).
+
+Integrity checks:
+- Drops rows missing required identifiers/datetime.
+- Deterministic dedupe by (event_id, team_id, home_away) keeping latest pulled_at_utc.
+- Logs pulled/upserted/rejected counts.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pandas as pd
+import psycopg
+
+DB_URL = (os.getenv("SUPABASE_DB_URL") or "").strip()
+RAW_SCHEMA = (os.getenv("RAW_SCHEMA") or "raw").strip()
+SRC_TABLE = (os.getenv("RAW_TEAM_LOGS_TABLE") or "espn_team_game_logs").strip()
+DST_TABLE = (os.getenv("RAW_TEAM_CORE_TABLE") or "espn_team_game_core").strip()
+SOURCE_NAME = (os.getenv("SOURCE") or "espn").strip()
+
+
+@dataclass
+class Counts:
+    pulled: int = 0
+    upserted: int = 0
+    rejected: int = 0
+
+
+def _must_env() -> None:
+    if not DB_URL:
+        raise RuntimeError("SUPABASE_DB_URL is required")
+
+
+def _quote_ident(v: str) -> str:
+    return '"' + v.replace('"', '""') + '"'
+
+
+def main() -> None:
+    _must_env()
+    qsrc = f'{_quote_ident(RAW_SCHEMA)}.{_quote_ident(SRC_TABLE)}'
+    qdst = f'{_quote_ident(RAW_SCHEMA)}.{_quote_ident(DST_TABLE)}'
+
+    sql = f"""
+      select
+        cast(event_id as text) as event_id,
+        cast(team_id as text) as team_id,
+        cast(team as text) as team,
+        lower(trim(cast(home_away as text))) as home_away,
+        game_datetime_utc,
+        points_for,
+        points_against,
+        fgm, fga, tpm, tpa, ftm, fta, tov, orb, drb,
+        pulled_at_utc,
+        source,
+        parse_version
+      from {qsrc}
+      where event_id is not null
+        and team_id is not null
+        and game_datetime_utc is not null
+    """
+
+    counts = Counts()
+
+    with psycopg.connect(DB_URL) as conn:
+        df = pd.read_sql(sql, conn)
+        counts.pulled = len(df)
+        if df.empty:
+            print("[WARN] No rows pulled from source logs")
+            return
+
+        before = len(df)
+        df = df[df["home_away"].isin(["home", "away"])].copy()
+        counts.rejected += before - len(df)
+
+        df["pulled_at_utc"] = pd.to_datetime(df["pulled_at_utc"], utc=True, errors="coerce")
+        df["game_datetime_utc"] = pd.to_datetime(df["game_datetime_utc"], utc=True, errors="coerce")
+        df = df.dropna(subset=["event_id", "team_id", "home_away", "game_datetime_utc"])
+
+        sort_cols = ["event_id", "team_id", "home_away", "pulled_at_utc"]
+        for c in sort_cols:
+            if c not in df.columns:
+                df[c] = pd.NaT
+        df = df.sort_values(sort_cols, ascending=[True, True, True, True])
+        df = df.drop_duplicates(subset=["event_id", "team_id", "home_away"], keep="last")
+
+        now = datetime.now(timezone.utc).isoformat()
+        records = []
+        cols = [
+            "event_id",
+            "team_id",
+            "team",
+            "home_away",
+            "game_datetime_utc",
+            "points_for",
+            "points_against",
+            "fgm", "fga", "tpm", "tpa", "ftm", "fta", "tov", "orb", "drb",
+            "pulled_at_utc",
+            "source",
+            "parse_version",
+            "verification_status",
+            "verification_notes",
+        ]
+
+        for _, r in df.iterrows():
+            records.append(
+                (
+                    str(r.get("event_id") or ""),
+                    str(r.get("team_id") or ""),
+                    str(r.get("team") or ""),
+                    str(r.get("home_away") or ""),
+                    r.get("game_datetime_utc"),
+                    r.get("points_for"),
+                    r.get("points_against"),
+                    r.get("fgm"), r.get("fga"), r.get("tpm"), r.get("tpa"), r.get("ftm"), r.get("fta"), r.get("tov"), r.get("orb"), r.get("drb"),
+                    r.get("pulled_at_utc"),
+                    str(r.get("source") or SOURCE_NAME),
+                    str(r.get("parse_version") or "v1"),
+                    "verified",
+                    f"built_from_{SRC_TABLE}_at_{now}",
+                )
+            )
+
+        upsert_sql = f"""
+            insert into {qdst} (
+              event_id, team_id, team, home_away, game_datetime_utc,
+              points_for, points_against,
+              fgm, fga, tpm, tpa, ftm, fta, tov, orb, drb,
+              pulled_at_utc, source, parse_version,
+              verification_status, verification_notes
+            )
+            values (
+              %s,%s,%s,%s,%s,
+              %s,%s,
+              %s,%s,%s,%s,%s,%s,%s,%s,%s,
+              %s,%s,%s,
+              %s,%s
+            )
+            on conflict (event_id, team_id, home_away)
+            do update set
+              team = excluded.team,
+              game_datetime_utc = excluded.game_datetime_utc,
+              points_for = excluded.points_for,
+              points_against = excluded.points_against,
+              fgm = excluded.fgm,
+              fga = excluded.fga,
+              tpm = excluded.tpm,
+              tpa = excluded.tpa,
+              ftm = excluded.ftm,
+              fta = excluded.fta,
+              tov = excluded.tov,
+              orb = excluded.orb,
+              drb = excluded.drb,
+              pulled_at_utc = excluded.pulled_at_utc,
+              source = excluded.source,
+              parse_version = excluded.parse_version,
+              verification_status = excluded.verification_status,
+              verification_notes = excluded.verification_notes;
+        """
+
+        with conn.cursor() as cur:
+            cur.executemany(upsert_sql, records)
+        conn.commit()
+        counts.upserted = len(records)
+
+    print(
+        f"[OK] {RAW_SCHEMA}.{DST_TABLE}: pulled={counts.pulled} upserted={counts.upserted} rejected={counts.rejected}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/supabase/RAW_FEATURES_REFACTOR_PLAN.md
+++ b/supabase/RAW_FEATURES_REFACTOR_PLAN.md
@@ -1,0 +1,33 @@
+# raw.espn_team_game_features refactor plan (storage reduction)
+
+## 1) Raw vs derived classification used in this refactor
+Because the live table DDL is not in this repo, classify columns by reproducibility rule:
+
+- **Raw (keep in DB)**: identifiers, provenance, box score primitives, and final game score primitives.
+- **Derived (compute in Python)**: any rate/rolling/window feature (`*_pct`, `*_pre`, `*_l3_pre`, `*_l7_pre`, `*_diff`, `exp_margin`, `style_distance`, etc.).
+
+**Kept raw columns (new table):**
+- Keys/meta: `event_id`, `team_id`, `team`, `home_away`, `game_datetime_utc`, `pulled_at_utc`, `source`, `parse_version`, `verification_status`, `verification_notes`
+- Score primitives: `points_for`, `points_against`
+- Box score primitives: `fgm`, `fga`, `tpm`, `tpa`, `ftm`, `fta`, `tov`, `orb`, `drb`
+
+Everything else is treated as recomputable.
+
+## 2) Why this is safe
+- These primitives are sufficient to recompute per-game metrics (`efg`, `ftr`, `3par`, `tov_pct`, `pace`, `ortg`, `drtg`, `netrtg`) and rolling pregame windows in Python.
+- The model matrix writer still outputs the same shape expected by training/predict (`*_l{window}_pre`, `games_last_*`, and downstream diffs).
+
+## 3) Migration + pipeline changes in this branch
+- New streamlined table migration: `supabase/migrations/20260308000000_create_raw_espn_team_game_core.sql`
+- New builder script: `scripts/build_espn_team_game_core.py`
+- `ml/feature_matrix.py` now derives rolling pregame features from core primitives when precomputed columns are not present.
+- CI workflow now builds the core table and points feature generation to `raw.espn_team_game_core`.
+
+## 4) Backfill command
+Run in CI/server context (service role DB URL):
+```bash
+python scripts/build_espn_team_game_core.py
+```
+
+## 5) Optional pruning after validation
+After validating predictions/training outputs are stable, stop loading `raw.espn_team_game_features` and archive/drop old rows in that table.

--- a/supabase/STORAGE_AUDIT_PLAYBOOK.md
+++ b/supabase/STORAGE_AUDIT_PLAYBOOK.md
@@ -1,0 +1,126 @@
+# Supabase Storage Audit + Reduction Playbook (CBB model)
+
+## Why this exists
+Your largest tables (`raw.espn_matchups_model_ready`, `public.team_game_features`, `raw.espn_team_game_features`) are feature-heavy and can grow fast.
+This playbook gives safe SQL checks before dropping/migrating anything.
+
+## 1) Confirm what is actually large (table vs indexes vs TOAST)
+```sql
+select
+  n.nspname as schema_name,
+  c.relname as table_name,
+  pg_size_pretty(pg_table_size(c.oid)) as table_heap,
+  pg_size_pretty(pg_indexes_size(c.oid)) as indexes,
+  pg_size_pretty(pg_total_relation_size(c.oid)) as total,
+  pg_size_pretty(pg_total_relation_size(c.reltoastrelid)) as toast_total
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+where c.relkind = 'r'
+  and (n.nspname, c.relname) in (
+    ('raw','espn_matchups_model_ready'),
+    ('raw','espn_team_game_features'),
+    ('public','team_game_features')
+  )
+order by pg_total_relation_size(c.oid) desc;
+```
+
+## 2) Find large JSON/text columns in those tables
+```sql
+select
+  table_schema,
+  table_name,
+  column_name,
+  data_type,
+  udt_name
+from information_schema.columns
+where (table_schema, table_name) in (
+    ('raw','espn_matchups_model_ready'),
+    ('raw','espn_team_game_features'),
+    ('public','team_game_features')
+  )
+  and udt_name in ('json', 'jsonb', 'text', 'varchar')
+order by table_schema, table_name, column_name;
+```
+
+## 3) Measure per-row payload weight (estimated average bytes)
+> Run one table at a time and adjust the selected columns to what exists.
+```sql
+-- Example for raw.espn_team_game_features
+select
+  count(*) as rows,
+  avg(pg_column_size(features))::bigint as avg_features_bytes,
+  avg(pg_column_size(t.*))::bigint as avg_row_bytes
+from raw.espn_team_game_features t;
+```
+
+```sql
+-- Example for public.team_game_features
+select
+  count(*) as rows,
+  avg(pg_column_size(features))::bigint as avg_features_bytes,
+  avg(pg_column_size(t.*))::bigint as avg_row_bytes
+from public.team_game_features t;
+```
+
+## 4) Redundancy checks before dropping raw staging tables
+```sql
+-- Are normalized features present for the same game/team pairs?
+select
+  count(*) as raw_rows,
+  count(distinct (event_id, team_id)) as raw_game_team_pairs
+from raw.espn_team_game_features;
+```
+
+```sql
+select
+  count(*) as public_rows,
+  count(distinct (game_id, team_id)) as public_game_team_pairs
+from public.team_game_features;
+```
+
+```sql
+-- Missing normalized rows by external_game_id mapping (spot check)
+select count(*) as missing_in_public
+from raw.espn_team_game_features r
+left join public.games g
+  on g.external_game_id = r.event_id
+left join public.team_game_features f
+  on f.game_id = g.id and f.team_id::text = r.team_id
+where f.id is null;
+```
+
+## 5) Archive old seasons (recommended first move)
+Create archive schema and move old rows (example cutoff before 2024-07-01 UTC):
+```sql
+create schema if not exists raw_archive;
+
+create table if not exists raw_archive.espn_team_game_features as
+select * from raw.espn_team_game_features where false;
+
+insert into raw_archive.espn_team_game_features
+select *
+from raw.espn_team_game_features
+where game_datetime_utc < '2024-07-01'::timestamptz;
+
+-- Validate row count before delete
+select count(*) from raw_archive.espn_team_game_features;
+
+-- Then prune primary table
+-- delete from raw.espn_team_game_features where game_datetime_utc < '2024-07-01'::timestamptz;
+```
+
+Do the same for `raw.espn_matchups_model_ready` if your current pipeline does not need historical rows in primary storage.
+
+## 6) Recommended target architecture (safe + under 500MB)
+1. Keep `public.team_game_features` as canonical model-ready store (jsonb `features` only).
+2. Keep `raw.*` as short-retention staging (e.g., current season + prior season).
+3. Archive older `raw.*` rows to `raw_archive.*` in DB or to Supabase Storage parquet/csv.
+4. Do **not** drop `raw.espn_team_game_features` immediately; `ml/feature_matrix.py` currently reads from it by default.
+5. If you later switch ML to read from `public.team_game_features`, then raw retention can be reduced further.
+
+## 7) Optional maintenance after large deletes
+```sql
+vacuum (analyze) raw.espn_team_game_features;
+vacuum (analyze) raw.espn_matchups_model_ready;
+```
+(Use `vacuum full` only during maintenance windows; it locks tables.)

--- a/supabase/migrations/20260307000000_add_l3_diff_columns_to_raw_model_features.sql
+++ b/supabase/migrations/20260307000000_add_l3_diff_columns_to_raw_model_features.sql
@@ -1,0 +1,14 @@
+-- Purpose:
+-- raw.model_features received new rolling-window diff columns in ml/model_features.csv.
+-- Add the missing nullable numeric columns so load_csv_to_db.py can load nightly CSVs without schema drift failures.
+
+alter table raw.model_features add column if not exists ortg_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists drtg_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists netrtg_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists pace_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists efg_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists tov_pct_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists orb_pct_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists drb_pct_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists ftr_l3_pre_diff double precision;
+alter table raw.model_features add column if not exists "3par_l3_pre_diff" double precision;

--- a/supabase/migrations/20260308000000_create_raw_espn_team_game_core.sql
+++ b/supabase/migrations/20260308000000_create_raw_espn_team_game_core.sql
@@ -1,0 +1,47 @@
+-- Streamlined raw ingestion table for ESPN team-game boxscore + score primitives.
+-- Purpose: keep only essential raw inputs in DB; compute rolling/derived ML features in Python.
+
+create table if not exists raw.espn_team_game_core (
+  id uuid primary key default gen_random_uuid(),
+  event_id text not null,
+  team_id text not null,
+  team text null,
+  home_away text not null check (home_away in ('home', 'away')),
+  game_datetime_utc timestamptz not null,
+
+  -- score primitives
+  points_for double precision null,
+  points_against double precision null,
+
+  -- boxscore primitives
+  fgm double precision null,
+  fga double precision null,
+  tpm double precision null,
+  tpa double precision null,
+  ftm double precision null,
+  fta double precision null,
+  tov double precision null,
+  orb double precision null,
+  drb double precision null,
+
+  pulled_at_utc timestamptz not null,
+  source text not null,
+  parse_version text not null,
+  verification_status text not null default 'partial',
+  verification_notes text null,
+
+  unique (event_id, team_id, home_away)
+);
+
+create index if not exists idx_espn_team_game_core_event on raw.espn_team_game_core (event_id);
+create index if not exists idx_espn_team_game_core_team_dt on raw.espn_team_game_core (team_id, game_datetime_utc);
+create index if not exists idx_espn_team_game_core_dt on raw.espn_team_game_core (game_datetime_utc);
+
+alter table raw.espn_team_game_core enable row level security;
+
+drop policy if exists raw_espn_team_game_core_read_authenticated on raw.espn_team_game_core;
+create policy raw_espn_team_game_core_read_authenticated
+on raw.espn_team_game_core
+for select
+to authenticated
+using (true);


### PR DESCRIPTION
### Motivation
- Reduce Supabase storage by removing wide precomputed feature columns from the DB and recomputing derived/rolling ML features in Python from a minimal raw table.
- Keep provenance, integrity, and reproducibility while providing a safe, incremental migration path (build slim core table first, validate parity, then archive/prune wide tables).
- Harden pipeline behavior so loads, schema drift, training, and prediction surface problems deterministically instead of failing silently.

### Description
- Added a new migration `supabase/migrations/20260308000000_create_raw_espn_team_game_core.sql` that creates `raw.espn_team_game_core` containing only identifiers, provenance, score primitives (`points_for`, `points_against`) and boxscore primitives (`fgm,fga,tpm,tpa,ftm,fta,tov,orb,drb`), plus indexes and an RLS read policy.
- Added `scripts/build_espn_team_game_core.py` to build/upsert the slim core table from `raw.espn_team_game_logs` with deterministic dedupe, required-field checks, and pulled/upserted/rejected logging.
- Updated `ml/feature_matrix.py` to default to `raw.espn_team_game_core` and to derive pre-game metrics and rolling lookback features in Python when precomputed `*_l7_pre` columns are absent; new helpers added: `_safe_div`, `_rolling_pre`, `_games_last_days`, and `_derive_features_if_needed` that compute `efg`, `ftr`, `3par`, `tov_pct`, `pace`, `ortg/drtg/netrtg`, rebound rates, `*_l{3,4,5,6,7,10,12}_pre`, `games_last_*` and `exp_margin`.
- CI/workflow updated (`.github/workflows/run-ml-pipeline.yml`) to run the core-table builder before `ml/pipeline.py` and `ml/feature_matrix.py` and to point the feature steps at `espn_team_game_core`.
- Loader `load_csv_to_db.py` gained schema-drift guidance: CSV numeric type inference, suggested `ALTER TABLE` SQL emission, and a guarded `ALLOW_SCHEMA_MIGRATION` flow so CI can surface schema fixes deterministically.
- ML robustness improvements: `ml/predict_ml.py` now emits prediction diagnostics and fails on constant/invalid predictions; `ml/train_ml_models.py` writes deterministic intercept-only fallback models when training cannot produce a valid model (low variance or other failures); `ml/train_variants.py` updated to tolerate missing window columns and to accept configurable feature path.
- Added operational docs: `supabase/RAW_FEATURES_REFACTOR_PLAN.md` and `supabase/STORAGE_AUDIT_PLAYBOOK.md` describing raw-vs-derived classification, backfill/prune guidance, and safe SQL checks.

### Testing
- Compiled relevant modules successfully with `python -m py_compile ml/feature_matrix.py scripts/build_espn_team_game_core.py load_csv_to_db.py` (succeeded).
- Ran a synthetic derivation sanity check calling `_derive_features_if_needed(...)` with a small in-memory DataFrame and confirmed rolling `*_l7_pre` columns and `games_last_*`/`exp_margin` were produced and a `[INFO] Derived pre-game rolling features from raw boxscore primitives` message printed (succeeded).
- Imported and exercised the builder script dataclass (`scripts/build_espn_team_game_core.Counts`) to ensure the script loads cleanly in the environment (succeeded).
- No database migration was executed in this workspace; the migration SQL file is included and must be applied in your Supabase environment to create `raw.espn_team_game_core` before running the backfill.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f797e2d00832b8ea1005e4b8da05d)