### PR TITLE
Fix daily scoreboard dispatch for modular ESPN import

### DIFF
--- a/scripts/daily_auto_predict.py
+++ b/scripts/daily_auto_predict.py
@@ -183,8 +183,18 @@ def fetch_scoreboard() -> pd.DataFrame:
         dates.append((now + timedelta(days=i)).strftime("%Y%m%d"))
 
     rows: List[Dict[str, object]] = []
+    fetch_fn = None
+    if hasattr(espn, "fetch_scoreboard_games"):
+        fetch_fn = espn.fetch_scoreboard_games
+    elif hasattr(espn, "fetch_scoreboard_games_for_date"):
+        fetch_fn = espn.fetch_scoreboard_games_for_date
+    else:
+        raise AttributeError(
+            "ESPN module must expose fetch_scoreboard_games or fetch_scoreboard_games_for_date"
+        )
+
     for d in dates:
-        rows.extend(espn.fetch_scoreboard_games(d))
+        rows.extend(fetch_fn(d))
     return pd.DataFrame(rows)
 
 


### PR DESCRIPTION
### Motivation
- The daily ingest pipeline crashed with `AttributeError` after preferring the modular ESPN client because the modular module exposes `fetch_scoreboard_games_for_date` rather than `fetch_scoreboard_games`, preventing scoreboard rows from being fetched and blocking downstream predictions/UI.

### Description
- Update `scripts/daily_auto_predict.py` `fetch_scoreboard()` to dynamically pick the available ESPN fetch function: prefer `fetch_scoreboard_games`, fall back to `fetch_scoreboard_games_for_date`, and raise a clear `AttributeError` if neither exists; change is isolated to that function.

### Testing
- Ran syntax validation with `python -m py_compile scripts/daily_auto_predict.py` which completed successfully with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa5792468832bae5ad75c26af2601)