### PR TITLE
Ensure predictions load in app: normalize fields, add app-facing keys, and robust upserts

### DIFF
--- a/scripts/daily_auto_predict.py
+++ b/scripts/daily_auto_predict.py
@@ -183,8 +183,18 @@ def fetch_scoreboard() -> pd.DataFrame:
         dates.append((now + timedelta(days=i)).strftime("%Y%m%d"))
 
     rows: List[Dict[str, object]] = []
+    fetch_fn = None
+    if hasattr(espn, "fetch_scoreboard_games"):
+        fetch_fn = espn.fetch_scoreboard_games
+    elif hasattr(espn, "fetch_scoreboard_games_for_date"):
+        fetch_fn = espn.fetch_scoreboard_games_for_date
+    else:
+        raise AttributeError(
+            "ESPN module must expose fetch_scoreboard_games or fetch_scoreboard_games_for_date"
+        )
+
     for d in dates:
-        rows.extend(espn.fetch_scoreboard_games(d))
+        rows.extend(fetch_fn(d))
     return pd.DataFrame(rows)
 
 
@@ -376,7 +386,14 @@ def main() -> None:
         model_version = MODEL_VERSION_OVERRIDE or str(row.get("model_version") or "").strip() or "ml-linear-v1"
 
         pred_margin_home = _safe_float(row.get("pred_margin_home"))
+        if pred_margin_home is None:
+            pred_margin_home = _safe_float(row.get("pred_spread"))
+        if pred_margin_home is None:
+            pred_margin_home = _safe_float(row.get("ensemble_prediction"))
+
         pred_total = _safe_float(row.get("pred_total"))
+        if pred_total is None:
+            pred_total = _safe_float(row.get("predicted_total"))
 
         market_spread = _safe_float(row.get("market_spread"))
         market_total = _safe_float(row.get("market_total"))
@@ -401,7 +418,7 @@ def main() -> None:
         prediction_rows.append(
             {
                 # required
-                "id": prediction_key,
+                "id": str(uuid.uuid5(uuid.NAMESPACE_URL, prediction_key)),
                 "prediction_key": prediction_key,
                 "model_version_id": model_version,
                 "game_date": str(row.get("date") or "").strip() or str(row.get("game_date") or "").strip(),
@@ -420,12 +437,22 @@ def main() -> None:
                 },
                 # optional / useful
                 "game_id": event_id,
+                "event_id": event_id,
+                "external_game_id": event_id,
+                "game_datetime_utc": _parse_game_datetime(row.to_dict()),
                 "home_team": (str(row.get("team_home") or row.get("home_team") or "").strip() or None),
                 "away_team": (str(row.get("team_away") or row.get("away_team") or "").strip() or None),
                 "venue": row.get("venue") or None,
                 "vegas_line": market_spread,
                 "vegas_edge": vegas_edge,
                 "vegas_total": market_total,
+                "pred_margin_home": pred_margin_home,
+                "pred_spread": pred_margin_home,
+                "pred_total": pred_total,
+                "market_spread": market_spread,
+                "market_total": market_total,
+                "edge_spread": vegas_edge,
+                "edge_total": total_edge,
                 "odds_provider": (row.get("market_provider") or "espn"),
                 "inputs": {
                     "predictions_latest_row_hash": str(row.get("row_hash") or ""),
@@ -439,13 +466,24 @@ def main() -> None:
     predictions_upserted = 0
     if prediction_rows:
         prediction_rows = [r for r in prediction_rows if r.get("prediction_key") and r.get("id")]
-        predictions_upserted = upsert_rows(
-            sb,
-            "public",
-            "predictions",
-            prediction_rows,
-            on_conflict="prediction_key",
-        )
+        try:
+            predictions_upserted = upsert_rows(
+                sb,
+                "public",
+                "predictions",
+                prediction_rows,
+                on_conflict="prediction_key",
+            )
+        except Exception as exc:
+            if "prediction_key" not in str(exc):
+                raise
+            predictions_upserted = upsert_rows(
+                sb,
+                "public",
+                "predictions",
+                prediction_rows,
+                on_conflict="model_version,external_game_id",
+            )
 
     counts = Counts(
         pulled=len(scoreboard),


### PR DESCRIPTION
### Motivation
- Predictions were not rendering in the UI because the daily pipeline wrote payloads with missing or mismatched prediction columns and lacked app-facing keys used by dashboard queries. This blocked model outputs from showing in the Daily Dashboard and slate views. 
- The change also makes the scoreboard fetch robust to ESPN modular vs legacy import function names.

### Description
- In `scripts/daily_auto_predict.py` add resilient prediction field mapping so spread and total are read from multiple possible columns (spread: `pred_margin_home` → `pred_spread` → `ensemble_prediction`; total: `pred_total` → `predicted_total`).
- Populate app-facing prediction fields in the upsert payload so UI queries can match on them (`event_id`, `external_game_id`, `game_datetime_utc`, `pred_margin_home`, `pred_spread`, `pred_total`, `market_spread`, `market_total`, `edge_spread`, `edge_total`).
- Generate deterministic UUID `id` from the composed `prediction_key` (UUID5) for compatibility with UUID-backed schemas, and add an upsert conflict-key fallback (try `prediction_key`, fallback to `model_version,external_game_id`).
- Make scoreboard pulling use whichever ESPN function is available (`fetch_scoreboard_games` or `fetch_scoreboard_games_for_date`) for modular/legacy compatibility; change is limited to `scripts/daily_auto_predict.py`.

### Testing
- Ran syntax check: `python -m py_compile scripts/daily_auto_predict.py`, which completed with no errors. 
- Performed local code inspection and dry-run edits to ensure mapping and payload fields are present; no DB-integration tests were run in this environment because Supabase credentials were not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa5792468832bae5ad75c26af2601)